### PR TITLE
Plugin to run commands when a new entry is deployed.

### DIFF
--- a/plugins/deploy_hooks/README.md
+++ b/plugins/deploy_hooks/README.md
@@ -1,0 +1,7 @@
+This is a signal handling plugin that lets you run custom commands or functions
+on new entries created since the last deployment.
+
+Your command can be a template that can be rendered by the templating engine
+that your theme uses or a simple Python callable.  The new entry/post is passed
+in the context to the templating engine, along with the command.  If the
+command is a callable, the entry is passed as an argument.

--- a/plugins/deploy_hooks/conf.py.sample
+++ b/plugins/deploy_hooks/conf.py.sample
@@ -1,0 +1,41 @@
+# List of commands that need to be run for each new entry created since the
+# last deployment of the site.  The commands can either be a "shell" command or
+# a python callable.
+# For example, you could post a new tweet each time you make a new post, using
+# either a shell command or a python function!
+#
+# from __future__ import print_function
+# def tweet(entry):
+#     from twitter import Twitter, OAuth, read_token_file
+#     from twitter.cmdline import CONSUMER_KEY, CONSUMER_SECRET, OPTIONS
+#     oauth_filename = OPTIONS['oauth_filename']
+#     oauth_token, oauth_token_secret = read_token_file(oauth_filename)
+#
+#     t = Twitter(
+#         auth=OAuth(
+#             oauth_token, oauth_token_secret, CONSUMER_KEY, CONSUMER_SECRET
+#         )
+#     )
+#     tags = ' '.join(['#' + tag for tag in entry.tags])
+#     url = entry.permalink(absolute=True)
+#     status = 'New Post: %s %s %s' % (entry.title(), url, tags)
+#     t.statuses.update(status=status)
+#
+# DEPLOYED_HOOKS = [
+#     "twitter set \"New Post: ${entry.title()} ${entry.permalink(absolute=True)} ${' '.join(['#'+tag for tag in entry.tags])}\"",
+#     tweet,
+# ]
+#
+#
+
+# Similar to the DEPLOYED_HOOKS variable, but the commands are run for each
+# new entry that has not been deployed either because it is a draft or a future
+# post.
+# For example, this can be used to setup a cron/at job to deploy the site,
+# after the time at which the post is scheduled.
+# UNDEPLOYED_HOOKS = [ ]
+
+# Set this to false, if you want the hooks to run on deployment after a clean.
+# If you set this to false, the hooks will essentially run on all the posts in
+# the site.
+# NO_HOOKS_ON_CLEAN = True

--- a/plugins/deploy_hooks/deploy_hooks.plugin
+++ b/plugins/deploy_hooks/deploy_hooks.plugin
@@ -1,0 +1,9 @@
+[Core]
+Name = deploy_hooks
+Module = deploy_hooks
+
+[Documentation]
+Author = Puneeth Chaganti
+Version = 0.1
+Website = http://getnikola.com
+Description = Lets you perform post deploy actions.

--- a/plugins/deploy_hooks/deploy_hooks.py
+++ b/plugins/deploy_hooks/deploy_hooks.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+
+# Copyright © 2012-2013 Puneeth Chaganti and others.
+
+# Permission is hereby granted, free of charge, to any
+# person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the
+# Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the
+# Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice
+# shall be included in all copies or substantial portions of
+# the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+# PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+# OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import subprocess
+import sys
+
+from blinker import signal
+
+from nikola.plugin_categories import SignalHandler
+from nikola.utils import get_logger
+
+
+class DeployHooks(SignalHandler):
+    """ Add custom actions to be performed when new posts are deployed. """
+
+    name = 'deploy_hooks'
+
+    def run_hooks(self, event):
+        """ Run the custom hooks that have been attached. """
+
+        if event['clean'] and self.site.config.get('NO_HOOKS_ON_CLEAN', True):
+            self.logger.notice("No hooks run, since site was cleaned.")
+            return
+
+        for entry_type in ('deployed', 'undeployed'):
+            for entry in event[entry_type]:
+                hook_key_name = '%s_HOOKS' % entry_type.upper()
+                for command in self.site.config.get(hook_key_name, []):
+
+                    if callable(command):
+                        command(entry)
+
+                    else:
+                        self._run_command(self._format_command(command, entry))
+
+    def set_site(self, site):
+        self.site = site
+        self.logger = get_logger(self.name, self.site.loghandlers)
+
+        ready = signal('deployed')
+        ready.connect(self.run_hooks)
+
+    def _format_command(self, template, entry):
+        """ Format a "templatised" command with an entry as the context. """
+
+        context = dict(entry=entry)
+
+        command = self.site.template_system.render_template_to_string(
+            template, context
+        )
+
+        return command
+
+    def _run_command(self, command):
+        """ Run the given command and log errors, if any. """
+
+        self.logger.notice("==> {0}".format(command))
+        try:
+            subprocess.check_call(command, shell=True)
+        except subprocess.CalledProcessError as e:
+            self.logger.error('Failed post deploy hook — command {0} '
+                              'returned {1}'.format(e.cmd, e.returncode))
+            sys.exit(e.returncode)


### PR DESCRIPTION
The plugin can be used to run specific commands for each new post/entry created since the last deployment, for example to make a new tweet every time a new post is made. 
