### PR TITLE
Use pygments for code block highlighting.

### DIFF
--- a/plugins/orgmode/init.el
+++ b/plugins/orgmode/init.el
@@ -12,8 +12,9 @@
 
 (require 'ox-html)
 
-;; Custom configuration for the export.
-;;; Add any custom configuration that you would like.
+;;; Custom configuration for the export. ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;; Add any custom configuration that you would like to 'conf.el'.
 (setq
  org-export-with-toc nil
  org-export-with-section-numbers nil
@@ -24,12 +25,86 @@
   (if (file-exists-p conf)
       (load-file conf)))
 
+;;; Macros ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 ;; Load Nikola macros
 (setq nikola-macro-templates
       (with-current-buffer
           (find-file
            (expand-file-name "macros.org" (file-name-directory load-file-name)))
         (org-macro--collect-macros)))
+
+
+;;; Code highlighting ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Use pygments highlighting for code
+(defun pygmentize (lang code)
+  "Use Pygments to highlight the given code and return the output"
+  (with-temp-buffer
+    (insert code)
+    (let ((lang (or (cdr (assoc lang org-pygments-language-alist)) "text")))
+      (shell-command-on-region (point-min) (point-max)
+                               (format "pygmentize -f html -g -l %s" lang)
+                               (buffer-name) t))
+
+    (buffer-string)))
+
+
+(defconst org-pygments-language-alist
+  '(
+    ("asymptote" . "asymptote")
+    ("awk" . "awk")
+    ("C" . "c")
+    ("cpp" . "cpp")
+    ("clojure" . "clojure")
+    ("css" . "css")
+    ("D" . "d")
+    ("emacs-lisp" . "scheme")
+    ("F90" . "fortran")
+    ("gnuplot" . "gnuplot")
+    ("groovy" . "groovy")
+    ("haskell" . "haskell")
+    ("java" . "java")
+    ("js" . "js")
+    ("julia" . "julia")
+    ("latex" . "latex")
+    ("lisp" . "lisp")
+    ("makefile" . "makefile")
+    ("matlab" . "matlab")
+    ("mscgen" . "mscgen")
+    ("ocaml" . "ocaml")
+    ("octave" . "octave")
+    ("perl" . "perl")
+    ("picolisp" . "scheme")
+    ("python" . "python")
+    ("R" . "r")
+    ("ruby" . "ruby")
+    ("sass" . "sass")
+    ("scala" . "scala")
+    ("scheme" . "scheme")
+    ("sh" . "sh")
+    ("sql" . "sql")
+    ("sqlite" . "sqlite3")
+    ("tcl" . "tcl")
+    )
+  "Alist between org-babel languages and Pygments lexers.
+
+See: http://orgmode.org/worg/org-contrib/babel/languages.html and
+http://pygments.org/docs/lexers/ for adding new languages to the
+mapping. ")
+
+;; Override the html export function to use pygments
+(defun org-html-src-block (src-block contents info)
+  "Transcode a SRC-BLOCK element from Org to HTML.
+CONTENTS holds the contents of the item.  INFO is a plist holding
+contextual information."
+  (if (org-export-read-attribute :attr_html src-block :textarea)
+      (org-html--textarea-block src-block)
+    (let ((lang (org-element-property :language src-block))
+	  (code (org-html-format-code src-block info)))
+      (pygmentize lang code))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Export function used by Nikola.
 (defun nikola-html-export (infile outfile)


### PR DESCRIPTION
Pygments is already a dependency for Nikola and this commit uses it
for highlighting all code blocks using the org-mode compiler.
