### PR TITLE
Fix issue with existing requirements-nonpy.txt syntax.

### DIFF
--- a/v7/asciidoc/requirements-nonpy.txt
+++ b/v7/asciidoc/requirements-nonpy.txt
@@ -1,1 +1,1 @@
-AsciiDoc:: http://www.methods.co.nz/asciidoc/
+AsciiDoc::http://www.methods.co.nz/asciidoc/

--- a/v7/less/requirements-nonpy.txt
+++ b/v7/less/requirements-nonpy.txt
@@ -1,1 +1,1 @@
-LESS:: http://lesscss.org
+LESS::http://lesscss.org

--- a/v7/sass/requirements-nonpy.txt
+++ b/v7/sass/requirements-nonpy.txt
@@ -1,1 +1,1 @@
-SASS:: http://sass-lang.com
+SASS::http://sass-lang.com


### PR DESCRIPTION
Currently, against nikola/master, plugin installation fails because it
is expecting a '::' separating the plugin name from the URL. This should
fix that.
