### PR TITLE
Fix problem with local search when site_url is not at the root

### DIFF
--- a/v7/localsearch/conf.py.sample
+++ b/v7/localsearch/conf.py.sample
@@ -1,7 +1,28 @@
+
 SEARCH_FORM = """
 <span class="navbar-form pull-left">
 <input type="text" id="tipue_search_input">
 </span>"""
+
+# The above search form puts the search results at the top of the
+# current page, which I found confusing when I was at the bottom of a
+# long page and the returned search results are rendered but out of my
+# viewport. I came across a blog post where someone was using the
+# search form below, which puts the results on a separate page. This
+# requires a source search.rst with the following single line content:
+#
+# <div id="tipue_search_content"></div>
+#
+# SEARCH_FORM = """
+# <span class="navbar-form pull-left">
+# <form action="/search.html">
+#      <div style="float: left;"><input type="text" name="q" id="tipue_search_input"></div>
+#      <div style="float: left; margin-left: 13px;"><input type="button" id="tipue_search_button" onclick="this.form.submit();"></div>
+# </form>
+
+</span>"""
+
+
 
 BODY_END = """
 <script src="/assets/js/tipuesearch_set.js"></script>
@@ -10,7 +31,7 @@ BODY_END = """
 $(document).ready(function() {
     $('#tipue_search_input').tipuesearch({
         'mode': 'json',
-        'contentLocation': '/assets/js/tipuesearch_content.json',
+        'contentLocation': '{site_folder}/assets/js/tipuesearch_content.json',
         'showUrl': false
     });
 });
@@ -22,3 +43,14 @@ EXTRA_HEAD_DATA = """
 <div id="tipue_search_content" style="margin-left: auto; margin-right: auto; padding: 20px;"></div>
 """
 
+
+
+from urlparse import urlparse
+
+site_folder = urlparse(SITE_URL).path
+if site_folder:
+    site_folder = site_folder.rstrip('/')
+else:
+    site_folder = ''
+    
+BODY_END = BODY_END.replace('{site_folder}', site_folder)

--- a/v7/localsearch/localsearch/__init__.py
+++ b/v7/localsearch/localsearch/__init__.py
@@ -34,6 +34,8 @@ from doit.tools import result_dep
 from nikola.plugin_categories import LateTask
 from nikola.utils import config_changed, copy_tree, makedirs
 
+from urlparse import urlparse
+
 # This is what we need to produce:
 # var tipuesearch = {"pages": [
 #     {"title": "Tipue Search, a jQuery site search engine", "text": "Tipue
@@ -81,7 +83,7 @@ class Tipue(LateTask):
                     data["title"] = post.title(lang)
                     data["text"] = text
                     data["tags"] = ",".join(post.tags)
-                    data["loc"] = post.permalink(lang)
+                    data["loc"] = urlparse(post.base_url).path.rstrip('/') + post.permalink(lang)
                     pages.append(data)
             output = json.dumps({"pages": pages}, indent=2)
             makedirs(os.path.dirname(dst_path))


### PR DESCRIPTION
When the site url is not at the root, the localsearch plugin __init__.py needed to be modified slightly to include the folder when using the post permalink. In addition, I added some corresponding comments to the conf.py.sample.