### PR TITLE
Implementation of feature request from issue #1460

### DIFF
--- a/v7/navstories/navstories.py
+++ b/v7/navstories/navstories.py
@@ -40,7 +40,7 @@ class NavStories(ConfigPlugin):
         for lang in site.config['NAVIGATION_LINKS'].values:
             new = []
             for p in site.pages:
-                if lang in p.translated_to:
+                if lang in p.translated_to and not p.meta('hidefromnav'):
                     new.append(p)
             new_entries = tuple(sorted([(p.permalink(lang), p.title(lang)) for p in new]))
 


### PR DESCRIPTION
issue [#1460](https://github.com/getnikola/nikola/issues/1460)
if pages/stories have set 'hidefromnav' in their metadata section, then they won't be added to the navigation
