### PR TITLE
Urls equal to Jekyll

### DIFF
--- a/v7/import_jekyll/import_jekyll.plugin
+++ b/v7/import_jekyll/import_jekyll.plugin
@@ -4,6 +4,6 @@ Module = import_jekyll
 
 [Documentation]
 Author = Miguel Angel Garcia
-Version = 0.1
+Version = 0.2
 Website = http://plugins.getnikola.com/#import_jekyll
 Description = Import a Jekyll or Octopress site.

--- a/v7/import_jekyll/import_jekyll.py
+++ b/v7/import_jekyll/import_jekyll.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright © 2014 Miguel Ángel García
+# Copyright © 2014,2015 Miguel Ángel García
 
 # Permission is hereby granted, free of charge, to any
 # person obtaining a copy of this software and associated


### PR DESCRIPTION
Generates urls exactly as Jekyll does.

It has still some drawbacks, because I use the "slugged" title and this may be different from what Jekyll does, but it will be closer.

In addition, it imports the option "PRETTY URLS"

I've increased the plugin version too.