### PR TITLE
Fixing headers.

### DIFF
--- a/v7/import_jekyll/import_jekyll.py
+++ b/v7/import_jekyll/import_jekyll.py
@@ -170,7 +170,7 @@ class JekyllPostImport(object):
         header = utils.write_metadata(metadata)
 
         pattern = '<!--\n{0}\n-->\n\n{1}' if is_html else '{0}\n\n{1}'
-        return pattern.format(header, doc)
+        return pattern.format(header.strip(), doc)
 
     def _split_metadata(self, path):
         with codecs.open(path, encoding='utf-8') as fd:

--- a/v7/import_jekyll/import_jekyll.py
+++ b/v7/import_jekyll/import_jekyll.py
@@ -278,7 +278,7 @@ class JekyllPostImport(object):
             )
             return re.sub(REGEX_LINK, link_repl, content)
 
-        for repl in (replace_code, replace_links):
+        for repl in (replace_code, replace_links, replace_teaser_mark):
             content = repl(content)
         return content
 


### PR DESCRIPTION
Two small fixes for headers:

1. Teaser mark wasn't being replaced.
2. New lines before the end comment mark of the header may be printed due to a bug in core, but fixed here.