### PR TITLE
Using th instead of td+b and fixing nested divs

### DIFF
--- a/v7/projectpages/templates/jinja/project.tmpl
+++ b/v7/projectpages/templates/jinja/project.tmpl
@@ -25,27 +25,27 @@
 
     <table class="table table-hover">
     <tr>
-    <td><b>Status</b></td>
+    <th>Status</th>
     <td>{{ project.status(post.meta('status')) }}</td>
     </tr>
 
     {% if post.meta('language') %}
     <tr>
-    <td><b>Language</b></td>
+    <th>Language</th>
     <td>{{ post.meta('language') }}</td>
     </tr>
     {% endif %}
 
     {% if post.meta('license') %}
     <tr>
-    <td><b>License</b></td>
+    <th>License</th>
     <td>{{ post.meta('license') }}</td>
     </tr>
     {% endif %}
 
     {% if post.meta('role') %}
     <tr>
-    <td><b>Role</b></td>
+    <th>Role</th>
     <td>{{ post.meta('role') }}</td>
     </tr>
     {% endif %}
@@ -75,8 +75,8 @@
     </div>
 
           {{ post.text(lang) }}
-      </div>
     {% if post.meta('logo') %}
-        </div>
+      </div>
+    </div>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
Two little improvements:

- I've changed the "td+b" tags by "th" what is more correct, and usually have no visual difference.
- I've fixed the nested "div" tags when no logo is provided.