### PR TITLE
ProjectPages: Avoid showing carousel if no featured pages

### DIFF
--- a/v7/projectpages/templates/jinja/projects.tmpl
+++ b/v7/projectpages/templates/jinja/projects.tmpl
@@ -6,6 +6,7 @@
         <h1>{{ title }}</h1>
     </header>
 
+{% if featured %}
 <div id="carousel-example-generic" class="carousel slide" data-ride="carousel">
   <!-- Indicators -->
   <ol class="carousel-indicators">
@@ -46,6 +47,7 @@ active
     <span class="glyphicon glyphicon-chevron-right"></span>
   </a>
 </div>
+{% endif %} {# end of if featured #}
 
 <h2>All projects</h2>
 

--- a/v7/projectpages/templates/mako/projects.tmpl
+++ b/v7/projectpages/templates/mako/projects.tmpl
@@ -6,6 +6,7 @@
         <h1>${title}</h1>
     </header>
 
+% if featured
 <div id="carousel-example-generic" class="carousel slide" data-ride="carousel">
   <!-- Indicators -->
   <ol class="carousel-indicators">
@@ -46,6 +47,7 @@ active
     <span class="glyphicon glyphicon-chevron-right"></span>
   </a>
 </div>
+% endif  ## end of if featured
 
 <h2>All projects</h2>
 


### PR DESCRIPTION
Avoid to show an empty carousel when there is not at least one featured page.