### PR TITLE
Display a bibtex link for each publication for easy citation.

### DIFF
--- a/tests/test_publication_list.py
+++ b/tests/test_publication_list.py
@@ -31,10 +31,10 @@ class TestPublication(ReSTExtensionTestCase):
         expected = (
             '<div class = "publication-list">'
             '<h3>2015</h3><ul>'
-            '<li class = "publication">.*One article in 2015.*</li>'
-            '<li class = "publication">.*One conference in 2015.*</li>'
+            '<li class = "publication">.*One article in 2015.*<a href="bibtex/a2015.bib">bibtex</a>.*</li>'
+            '<li class = "publication">.*One conference in 2015.*<a href="bibtex/p2015.bib">bibtex</a>.*</li>'
             '</ul><h3>2010</h3><ul>'
-            '<li class = "publication">.*One Book in 2010.*</li>'
+            '<li class = "publication">.*One Book in 2010.*<a href="bibtex/b2010.bib">bibtex</a>.*</li>'
             '</ul></div>'
         )
         self.sample = '.. publication_list:: tests/data/publication_list/test.bib'

--- a/v7/publication_list/README.md
+++ b/v7/publication_list/README.md
@@ -3,16 +3,25 @@
 A Nikola plugin to easily manage publication list.
 
 This plugin provides a directive `publication-list`, which reads a BibTeX file
-and display the references in them on the web page. The `publication-list`
-directive accepts one option `:style:`, which is the style of the bibliography.
-All available styles are provided by [Pybtex][]. You can see the
-[list of styles][] in the Pybtex repository. The default style is `unsrt`.
+and display the references in them on the web page.
 
 The publications are displayed in the following way. All publications are sorted
 by year in reverse order, i.e., recent publication first. Publications in the
 same year are grouped together with a year subtitle. Within the same year,
 publications are sorted by order they appear in the BibTeX file. Finally, each
 publication is formatted with the designated style.
+
+## Options
+
+The `publication-list` directive accepts multiple options.
+
+* `:style:` indicates the style of the bibliography. All available styles are
+  provided by [Pybtex][]. You can see the [list of styles][] in the Pybtex
+  repository. The default style is `unsrt`.
+
+* `:bibtex_dir:` indicates the directory where the bibtex file of each
+  publication is generated. If empty, no bibtex file will be created for each
+  publication. The default is `bibtex`.
 
 ## Example
 


### PR DESCRIPTION
This behavior is controlled by the option `:bibtex_dir:`, as explained in README.