### PR TITLE
fixing delimiters

### DIFF
--- a/v7/rest_html5/conf.py.sample
+++ b/v7/rest_html5/conf.py.sample
@@ -1,6 +1,6 @@
 COMPILERS = {
     'rest': ('.rst4',),
-    'rest_html5': ('.rst', '.txt',}
+    'rest_html5': ('.rst', '.txt'),
 }
 
 POSTS = (


### PR DESCRIPTION
the closing parenthesis is wrongly typed (brace) and placed (after the coma)