### PR TITLE
Update pyplots.py

### DIFF
--- a/v7/pyplots/pyplots.py
+++ b/v7/pyplots/pyplots.py
@@ -30,6 +30,8 @@ import os
 
 from docutils import nodes
 from docutils.parsers.rst import directives
+from docutils.parsers.rst.directives import images
+
 try:
     import matplotlib
     import matplotlib._pylab_helpers
@@ -54,11 +56,11 @@ class Plugin(RestExtension):
         PyPlot.out_dir = os.path.join(site.config['OUTPUT_FOLDER'], 'pyplots')
         return super(Plugin, self).set_site(site)
 
-pyplot_spec = directives.images.Image.option_spec
+pyplot_spec = images.Image.option_spec
 pyplot_spec['include-source'] = directives.flag
 
 
-class PyPlot(directives.images.Image):
+class PyPlot(images.Image):
     """ Reimplementation of http://matplotlib.org/sampledoc/extensions.html#inserting-matplotlib-plots."""
 
     has_content = True


### PR DESCRIPTION
First, we successfully install the `pyplots` plugin as instructed:
```
$ nikola plugin -i pyplots
[2016-02-02T02:56:51Z] NOTICE: plugin: No site found, assuming --user
[2016-02-02T02:56:51Z] INFO: requests.packages.urllib3.connectionpool: Starting new HTTPS connection (1): plugins.getnikola.com
[2016-02-02T02:56:51Z] INFO: plugin: Downloading 'https://plugins.getnikola.com/v7/pyplots.zip'
[2016-02-02T02:56:51Z] INFO: requests.packages.urllib3.connectionpool: Starting new HTTPS connection (1): plugins.getnikola.com
[2016-02-02T02:56:52Z] INFO: plugin: Extracting: pyplots into /Users/tiao/.nikola/plugins/
[2016-02-02T02:56:52Z] NOTICE: plugin: This plugin has Python dependencies.
[2016-02-02T02:56:52Z] INFO: plugin: Installing dependencies with pip...
Collecting matplotlib (from -r /Users/tiao/.nikola/plugins/pyplots/requirements.txt (line 1))
  Downloading matplotlib-1.5.1-cp35-cp35m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl (49.7MB)
    100% |████████████████████████████████| 49.7MB 11kB/s 
Collecting cycler (from matplotlib->-r /Users/tiao/.nikola/plugins/pyplots/requirements.txt (line 1))
  Downloading cycler-0.9.0-py2.py3-none-any.whl
Requirement already satisfied (use --upgrade to upgrade): python-dateutil in ./.virtualenvs/blog/lib/python3.5/site-packages (from matplotlib->-r /Users/tiao/.nikola/plugins/pyplots/requirements.txt (line 1))
Collecting pytz (from matplotlib->-r /Users/tiao/.nikola/plugins/pyplots/requirements.txt (line 1))
  Downloading pytz-2015.7-py2.py3-none-any.whl (476kB)
    100% |████████████████████████████████| 479kB 687kB/s 
Collecting numpy>=1.6 (from matplotlib->-r /Users/tiao/.nikola/plugins/pyplots/requirements.txt (line 1))
  Downloading numpy-1.10.4-cp35-cp35m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl (3.7MB)
    100% |████████████████████████████████| 3.7MB 127kB/s 
Collecting pyparsing!=2.0.0,!=2.0.4,>=1.5.6 (from matplotlib->-r /Users/tiao/.nikola/plugins/pyplots/requirements.txt (line 1))
  Downloading pyparsing-2.0.7-py2.py3-none-any.whl
Requirement already satisfied (use --upgrade to upgrade): six in ./.virtualenvs/blog/lib/python3.5/site-packages (from cycler->matplotlib->-r /Users/tiao/.nikola/plugins/pyplots/requirements.txt (line 1))
Installing collected packages: cycler, pytz, numpy, pyparsing, matplotlib
Successfully installed cycler-0.9.0 matplotlib-1.5.1 numpy-1.10.4 pyparsing-2.0.7 pytz-2015.7
[2016-02-02T02:57:30Z] INFO: plugin: Dependency installation succeeded.
```
However, when we try to run, say `nikola --help new_post` we encounter the following error:
```
$ nikola --help new_post
[2016-02-02T03:01:52Z] ERROR: yapsy: Unable to import plugin: /Users/tiao/.nikola/plugins/pyplots/pyplots
Traceback (most recent call last):
  File "/Users/tiao/.virtualenvs/blog/lib/python3.5/site-packages/yapsy/PluginManager.py", line 488, in loadPlugins
    candidate_module = imp.load_module(plugin_module_name,plugin_file,candidate_filepath+".py",("py","r",imp.PY_SOURCE))
  File "/Users/tiao/.virtualenvs/blog/lib/python3.5/imp.py", line 234, in load_module
    return load_source(name, filename, file)
  File "/Users/tiao/.virtualenvs/blog/lib/python3.5/imp.py", line 172, in load_source
    module = _load(spec)
  File "<frozen importlib._bootstrap>", line 693, in _load
  File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 662, in exec_module
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "/Users/tiao/.nikola/plugins/pyplots/pyplots.py", line 57, in <module>
    pyplot_spec = directives.images.Image.option_spec
AttributeError: module 'docutils.parsers.rst.directives' has no attribute 'images'
```
Note that we are using `docutils==0.12` here. Please also refer to: https://github.com/sphinx-doc/sphinx/issues/1361

It appears the structure of the modules have changed, but we can circumvent this by importing `images` as separate module:
```
$ python
Python 3.5.1 (default, Dec 14 2015, 23:34:36) 
[GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from docutils.parsers.rst import directives
>>> class PyPlot(directives.images.Image):
...     pass
... 
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'docutils.parsers.rst.directives' has no attribute 'images'
>>> from docutils.parsers.rst.directives import images
>>> class PyPlot(images.Image):
...     pass
... 
```
This PR makes the necessary changes to reflect the above.