### PR TITLE
Added new plugin "issue_role"

### DIFF
--- a/v6/issue_role/README.md
+++ b/v6/issue_role/README.md
@@ -1,0 +1,16 @@
+This plugin adds a new reStructuredText role `:issue:`, which automatically
+creates URLs pointing to the respective issue on the tracker defined in
+`ISSUE_URL`.
+
+Currently, the URL needs to be set in the `ISSUE_URL` variable in
+`issue_role.py`.
+
+`{issue}` will be replaced with the text provided to the `:issue:`
+reStructuredText role.
+
+Example:
+
+When you set `ISSUE_URL` to `http://tracker.yoursite.com/issue/{issue}`
+using ``:issue:`FOO-123` `` in your post will be converted to:
+`<a href="http://tracker.yoursite.com/issue/FOO-123">FOO-123</a>` in the
+resulting HTML page.

--- a/v6/issue_role/conf.py.sample
+++ b/v6/issue_role/conf.py.sample
@@ -8,4 +8,4 @@
 #  using ":issue:`FOO-123`" in your post will be converted to:
 #  <a href="http://tracker.yoursite.com/issue/FOO-123">FOO-123</a>
 #
-ISSUE_URL = http://tracker.yoursite.com/issue/{issue}
+ISSUE_URL = "http://tracker.yoursite.com/issue/{issue}"

--- a/v6/issue_role/conf.py.sample
+++ b/v6/issue_role/conf.py.sample
@@ -1,0 +1,11 @@
+#
+# URL for the issue_role reST plugin. {issue} will be replaced with the text
+# provided to the ":issue:" reStructuredText role.
+#
+# Example:
+#
+#  When you set ISSUE_URL to "http://tracker.yoursite.com/issue/{issue}"
+#  using ":issue:`FOO-123`" in your post will be converted to:
+#  <a href="http://tracker.yoursite.com/issue/FOO-123">FOO-123</a>
+#
+ISSUE_URL = http://tracker.yoursite.com/issue/{issue}

--- a/v6/issue_role/issue_role.plugin
+++ b/v6/issue_role/issue_role.plugin
@@ -1,0 +1,13 @@
+[Core]
+Name = issue_role
+Module = issue_role
+
+[Nikola]
+Compiler = rest
+plugincategory = CompilerExtension
+
+[Documentation]
+Author = Lenz Grimmer
+Version = 0.1
+website = https://plugins.getnikola.com/#issue_role
+description = Convert issue tracker IDs into URLs

--- a/v6/issue_role/issue_role.py
+++ b/v6/issue_role/issue_role.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+
+# Copyright © 2016 Lenz Grimmer
+
+# Permission is hereby granted, free of charge, to any
+# person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the
+# Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the
+# Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice
+# shall be included in all copies or substantial portions of
+# the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+# PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+# OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+from docutils import nodes
+from docutils.parsers.rst import roles
+
+from nikola.plugin_categories import RestExtension
+
+
+class Plugin(RestExtension):
+    """Plugin for issue role."""
+
+    name = 'issue_role'
+
+    def set_site(self, site):
+        """Set Nikola site."""
+        self.site = site
+        roles.register_local_role('issue', IssueRole)
+        IssueRole.site = site
+        return super(Plugin, self).set_site(site)
+
+def IssueRole(name, rawtext, text, lineno, inliner,
+             options={}, content=[]):
+    """Replace Issue ID with URL to issue tracker
+
+    Usage:
+
+      :issue:`ISSUE_ID`
+
+    """
+
+    # TODO: make ISSUE_URL configurable via conf.py
+    ISSUE_URL = "http://tracker.yoursite.com/issue/{issue}"
+
+    format_options = {
+        'issue': text
+    }
+
+    return [nodes.reference(rawtext, text, refuri=ISSUE_URL.format(**format_options), *options)], []

--- a/v6/issue_role/issue_role.py
+++ b/v6/issue_role/issue_role.py
@@ -29,6 +29,8 @@ from docutils.parsers.rst import roles
 
 from nikola.plugin_categories import RestExtension
 
+ISSUE_URL = ""
+
 
 class Plugin(RestExtension):
     """Plugin for issue role."""
@@ -39,11 +41,14 @@ class Plugin(RestExtension):
         """Set Nikola site."""
         self.site = site
         roles.register_local_role('issue', IssueRole)
+        global ISSUE_URL
+        ISSUE_URL = site.config['ISSUE_URL']
         IssueRole.site = site
         return super(Plugin, self).set_site(site)
 
+
 def IssueRole(name, rawtext, text, lineno, inliner,
-             options={}, content=[]):
+              options={}, content=[]):
     """Replace Issue ID with URL to issue tracker
 
     Usage:
@@ -51,9 +56,6 @@ def IssueRole(name, rawtext, text, lineno, inliner,
       :issue:`ISSUE_ID`
 
     """
-
-    # TODO: make ISSUE_URL configurable via conf.py
-    ISSUE_URL = "http://tracker.yoursite.com/issue/{issue}"
 
     format_options = {
         'issue': text


### PR DESCRIPTION
This plugin adds a new reST role `:issue:`, that converts issue IDs to URLs pointing to an issue tracker.

Currently, the issue tracker's URL needs to be configured in the `issue_role.py` plugin file - I have not yet figured out how to obtain this as a configuration option from `conf.py`. Any suggestions on how to achieve this would be appreciated.

Signed-off-by: Lenz Grimmer <lenz@grimmer.com>