### PR TITLE
Allow tags plugin to manipulate posts not in feed. 

### DIFF
--- a/tests/test_command_tags.py
+++ b/tests/test_command_tags.py
@@ -111,8 +111,8 @@ class TestCommandTagsHelpers(TestCommandTagsBase):
         new_tags = add_tags(self._site, tags, posts)
         new_parsed_tags = self._parse_new_tags(posts[0])
 
-        self.assertTrue('test_nikola' in new_tags)
-        self.assertEquals(set(new_tags), set(new_parsed_tags))
+        self.assertTrue('test_nikola' in new_tags[0])
+        self.assertEquals(set(new_tags[0]), set(new_parsed_tags))
 
     def test_add_dry_run(self):
         posts = [os.path.join('posts', post) for post in os.listdir('posts')]
@@ -121,7 +121,7 @@ class TestCommandTagsHelpers(TestCommandTagsBase):
         new_tags = add_tags(self._site, tags, posts, dry_run=True)
         new_parsed_tags = self._parse_new_tags(posts[0])
 
-        self.assertTrue('test_nikola' in new_tags)
+        self.assertTrue('test_nikola' in new_tags[0])
         self.assertEquals(set(new_parsed_tags), set(DEMO_TAGS))
 
     def test_auto_tag_basic(self):
@@ -175,7 +175,7 @@ class TestCommandTagsHelpers(TestCommandTagsBase):
         new_parsed_tags = self._parse_new_tags(posts[0])
 
         self.assertFalse('nikola' in new_tags)
-        self.assertEquals(set(new_tags), set(new_parsed_tags))
+        self.assertEquals(set(new_tags[0]), set(new_parsed_tags))
 
     def test_merge_dry_run(self):
         posts = [os.path.join('posts', post) for post in os.listdir('posts')]
@@ -184,7 +184,7 @@ class TestCommandTagsHelpers(TestCommandTagsBase):
         new_tags = merge_tags(self._site, tags, posts, dry_run=True)
         new_parsed_tags = self._parse_new_tags(posts[0])
 
-        self.assertFalse('nikola' in new_tags)
+        self.assertFalse('nikola' in new_tags[0])
         self.assertEquals(set(DEMO_TAGS), set(new_parsed_tags))
 
     def test_remove(self):
@@ -195,7 +195,7 @@ class TestCommandTagsHelpers(TestCommandTagsBase):
         new_parsed_tags = self._parse_new_tags(posts[0])
 
         self.assertFalse('nikola' in new_tags)
-        self.assertEquals(set(new_tags), set(new_parsed_tags))
+        self.assertEquals(set(new_tags[0]), set(new_parsed_tags))
 
     def test_remove_draft(self):
         self._add_test_post(title='2', tags=['draft'])
@@ -215,7 +215,7 @@ class TestCommandTagsHelpers(TestCommandTagsBase):
         new_tags = remove_tags(self._site, tags, posts)
         new_parsed_tags = self._parse_new_tags(posts[0])
 
-        self.assertEquals(set(new_tags), set(new_parsed_tags))
+        self.assertEquals(set(new_tags[0]), set(new_parsed_tags))
 
     def test_remove_dry_run(self):
         posts = [os.path.join('posts', post) for post in os.listdir('posts')]
@@ -224,7 +224,7 @@ class TestCommandTagsHelpers(TestCommandTagsBase):
         new_tags = remove_tags(self._site, tags, posts, dry_run=True)
         new_parsed_tags = self._parse_new_tags(posts[0])
 
-        self.assertFalse('nikola' in new_tags)
+        self.assertFalse('nikola' in new_tags[0])
         self.assertEquals(set(new_parsed_tags), set(DEMO_TAGS))
 
     def test_search(self):
@@ -244,7 +244,7 @@ class TestCommandTagsHelpers(TestCommandTagsBase):
         new_parsed_tags = self._parse_new_tags(posts[0])
 
         self.assertEquals(sorted(DEMO_TAGS), new_parsed_tags)
-        self.assertEquals(sorted(DEMO_TAGS), new_tags)
+        self.assertEquals(sorted(DEMO_TAGS), new_tags[0])
 
     def test_sort_dry_run(self):
         posts = [os.path.join('posts', post) for post in os.listdir('posts')]
@@ -254,7 +254,7 @@ class TestCommandTagsHelpers(TestCommandTagsBase):
         new_parsed_tags = self._parse_new_tags(posts[0])
 
         self.assertEquals(old_parsed_tags, new_parsed_tags)
-        self.assertEquals(sorted(DEMO_TAGS), new_tags)
+        self.assertEquals(sorted(DEMO_TAGS), new_tags[0])
 
 
 class TestCommandTags(TestCommandTagsBase):

--- a/tests/test_command_tags.py
+++ b/tests/test_command_tags.py
@@ -161,6 +161,12 @@ class TestCommandTagsHelpers(TestCommandTagsBase):
         tags = list_tags(self._site, 'count')
         self.assertEquals('python', tags[0])
 
+    def test_list_draft(self):
+        self._add_test_post(title='2', tags=['python', 'draft'])
+        self._force_scan()
+        tags = list_tags(self._site)
+        self.assertIn('draft', tags)
+
     def test_merge(self):
         posts = [os.path.join('posts', post) for post in os.listdir('posts')]
         tags = 'nikola, python'
@@ -190,6 +196,17 @@ class TestCommandTagsHelpers(TestCommandTagsBase):
 
         self.assertFalse('nikola' in new_tags)
         self.assertEquals(set(new_tags), set(new_parsed_tags))
+
+    def test_remove_draft(self):
+        self._add_test_post(title='2', tags=['draft'])
+        self._force_scan()
+        posts = [os.path.join('posts', post) for post in os.listdir('posts')]
+
+        remove_tags(self._site, 'draft', posts)
+        self._force_scan()
+
+        tags = list_tags(self._site, 'count')
+        self.assertNotIn('draft', tags)
 
     def test_remove_invalid(self):
         posts = [os.path.join('posts', post) for post in os.listdir('posts')]

--- a/tests/test_command_tags.py
+++ b/tests/test_command_tags.py
@@ -13,6 +13,13 @@ from nikola import nikola
 PLUGIN_PATH = os.path.abspath(os.path.join('v6', 'tags'))
 sys.path.append(PLUGIN_PATH)
 
+try:
+    from freezegun import freeze_time
+    _freeze_time = True
+except ImportError:
+    _freeze_time = False
+    freeze_time = lambda x: lambda y: y
+
 from tags import (
     _AutoTag, add_tags, list_tags, merge_tags, remove_tags, search_tags,
     sort_tags
@@ -166,6 +173,19 @@ class TestCommandTagsHelpers(TestCommandTagsBase):
         self._force_scan()
         tags = list_tags(self._site)
         self.assertIn('draft', tags)
+
+    def test_list_draft_post_tags(self):
+        self._add_test_post(title='2', tags=['ruby', 'draft'])
+        self._force_scan()
+        tags = list_tags(self._site)
+        self.assertIn('ruby', tags)
+
+    @unittest.skipIf(not _freeze_time, 'freezegun package not installed.')
+    def test_list_scheduled_post_tags(self):
+        with freeze_time("2012-01-14"):
+            self._force_scan()
+            tags = list_tags(self._site)
+            self.assertIn('python', tags)
 
     def test_merge(self):
         posts = [os.path.join('posts', post) for post in os.listdir('posts')]

--- a/v6/tags/tags.plugin
+++ b/v6/tags/tags.plugin
@@ -5,6 +5,6 @@ Tests = test_command_tags
 
 [Documentation]
 Author = Puneeth Chaganti
-Version = 0.5
+Version = 0.6
 Website = http://plugins.getnikola.com/#tags
 Description = Manage the tags for your site.

--- a/v6/tags/tags.py
+++ b/v6/tags/tags.py
@@ -258,6 +258,7 @@ def _post_tags(post):
 
     return tags
 
+
 def _posts_per_tag(site, include_special=True):
     tags = site.posts_per_tag.copy()
     if not include_special:
@@ -276,7 +277,6 @@ def _posts_per_tag(site, include_special=True):
                 tags[tag].append(post)
 
     return tags
-
 
 
 class CommandTags(Command):

--- a/v6/tags/tags.py
+++ b/v6/tags/tags.py
@@ -57,9 +57,11 @@ def add_tags(site, tags, filepaths, dry_run=False):
     OLD = 'old'
     NEW = 'new'
 
+    all_new_tags = []
     for post in posts:
         old_tags = _post_tags(post)
         new_tags = _add_tags(old_tags[:], tags)
+        all_new_tags.append(new_tags)
 
         if dry_run:
             print(FMT.format(
@@ -69,7 +71,7 @@ def add_tags(site, tags, filepaths, dry_run=False):
         elif new_tags != old_tags:
             _replace_tags_line(post, new_tags)
 
-    return new_tags
+    return all_new_tags
 
 
 def list_tags(site, sorting='alpha'):
@@ -120,9 +122,11 @@ def merge_tags(site, tags, filepaths, dry_run=False):
     OLD = 'old'
     NEW = 'new'
 
+    all_new_tags = []
     for post in posts:
         old_tags = _post_tags(post)
         new_tags = _clean_tags(old_tags[:], set(tags[:-1]), tags[-1])
+        all_new_tags.append(new_tags)
 
         if dry_run:
             print(FMT.format(
@@ -132,7 +136,7 @@ def merge_tags(site, tags, filepaths, dry_run=False):
         elif new_tags != old_tags:
             _replace_tags_line(post, new_tags)
 
-    return new_tags
+    return all_new_tags
 
 
 def remove_tags(site, tags, filepaths, dry_run=False):
@@ -159,9 +163,11 @@ def remove_tags(site, tags, filepaths, dry_run=False):
     if len(posts) == 0:
         new_tags = []
 
+    all_new_tags = []
     for post in posts:
         old_tags = _post_tags(post)
         new_tags = _remove_tags(old_tags[:], tags)
+        all_new_tags.append(new_tags)
 
         if dry_run:
             print(FMT.format(
@@ -171,7 +177,7 @@ def remove_tags(site, tags, filepaths, dry_run=False):
         elif new_tags != old_tags:
             _replace_tags_line(post, new_tags)
 
-    return new_tags
+    return all_new_tags
 
 
 def search_tags(site, term):
@@ -218,9 +224,11 @@ def sort_tags(site, filepaths, dry_run=False):
     OLD = 'old'
     NEW = 'new'
 
+    all_new_tags = []
     for post in posts:
         old_tags = _post_tags(post)
         new_tags = sorted(old_tags)
+        all_new_tags.append(new_tags)
 
         if dry_run:
             print(FMT.format(
@@ -230,7 +238,7 @@ def sort_tags(site, filepaths, dry_run=False):
         elif new_tags != old_tags:
             _replace_tags_line(post, new_tags)
 
-    return new_tags
+    return all_new_tags
 
 
 def _format_doc_string(function):

--- a/v6/tags/tags.py
+++ b/v6/tags/tags.py
@@ -263,13 +263,17 @@ def _posts_per_tag(site, include_special=True):
     if not include_special:
         return tags
 
-    drafts = [post for post in site.all_posts if post.is_draft]
-    if len(drafts) > 0:
-        tags.update({'draft': drafts})
+    skipped_posts = [post for post in site.all_posts if not post.use_in_feeds]
+    for post in skipped_posts:
+        post_tags = post.tags
+        if post.is_draft:
+            post_tags.append('draft')
+        if post.is_private:
+            post_tags.append('private')
 
-    private = [post for post in site.all_posts if post.is_private]
-    if len(private) > 0:
-        tags.update({'private': private})
+        for tag in post_tags:
+            if post not in tags[tag]:
+                tags[tag].append(post)
 
     return tags
 

--- a/v6/tags/tags.py
+++ b/v6/tags/tags.py
@@ -58,14 +58,15 @@ def add_tags(site, tags, filepaths, dry_run=False):
     NEW = 'new'
 
     for post in posts:
-        new_tags = _add_tags(post.tags[:], tags)
+        old_tags = _post_tags(post)
+        new_tags = _add_tags(old_tags[:], tags)
 
         if dry_run:
             print(FMT.format(
-                post.source_path, OLD, post.tags, NEW, new_tags)
+                post.source_path, OLD, old_tags, NEW, new_tags)
             )
 
-        elif new_tags != post.tags:
+        elif new_tags != old_tags:
             _replace_tags_line(post, new_tags)
 
     return new_tags
@@ -79,15 +80,15 @@ def list_tags(site, sorting='alpha'):
 
     """
 
-    tags = site.posts_per_tag
+    posts_per_tag = _posts_per_tag(site)
     if sorting == 'count':
-        tags = sorted(tags, key=lambda tag: len(tags[tag]), reverse=True)
+        tags = sorted(posts_per_tag, key=lambda tag: len(posts_per_tag[tag]), reverse=True)
     else:
-        tags = sorted(site.posts_per_tag.keys())
+        tags = sorted(posts_per_tag)
 
     for tag in tags:
         if sorting == 'count':
-            show = '{0:>4} {1}'.format(len(site.posts_per_tag[tag]), tag)
+            show = '{0:>4} {1}'.format(len(posts_per_tag[tag]), tag)
         else:
             show = tag
         print(show)
@@ -120,14 +121,15 @@ def merge_tags(site, tags, filepaths, dry_run=False):
     NEW = 'new'
 
     for post in posts:
-        new_tags = _clean_tags(post.tags[:], set(tags[:-1]), tags[-1])
+        old_tags = _post_tags(post)
+        new_tags = _clean_tags(old_tags[:], set(tags[:-1]), tags[-1])
 
         if dry_run:
             print(FMT.format(
-                post.source_path, OLD, post.tags, NEW, new_tags)
+                post.source_path, OLD, old_tags, NEW, new_tags)
             )
 
-        elif new_tags != post.tags:
+        elif new_tags != old_tags:
             _replace_tags_line(post, new_tags)
 
     return new_tags
@@ -158,14 +160,15 @@ def remove_tags(site, tags, filepaths, dry_run=False):
         new_tags = []
 
     for post in posts:
-        new_tags = _remove_tags(post.tags[:], tags)
+        old_tags = _post_tags(post)
+        new_tags = _remove_tags(old_tags[:], tags)
 
         if dry_run:
             print(FMT.format(
-                post.source_path, OLD, post.tags, NEW, new_tags)
+                post.source_path, OLD, old_tags, NEW, new_tags)
             )
 
-        elif new_tags != post.tags:
+        elif new_tags != old_tags:
             _replace_tags_line(post, new_tags)
 
     return new_tags
@@ -178,11 +181,11 @@ def search_tags(site, term):
 
     """
 
-    tags = site.posts_per_tag
+    posts_per_tag = _posts_per_tag(site)
     search_re = re.compile(term.lower())
 
     matches = [
-        tag for tag in tags
+        tag for tag in posts_per_tag
         if term in tag.lower() or search_re.match(tag.lower())
     ]
 
@@ -216,14 +219,15 @@ def sort_tags(site, filepaths, dry_run=False):
     NEW = 'new'
 
     for post in posts:
-        new_tags = sorted(post.tags)
+        old_tags = _post_tags(post)
+        new_tags = sorted(old_tags)
 
         if dry_run:
             print(FMT.format(
-                post.source_path, OLD, post.tags, NEW, new_tags)
+                post.source_path, OLD, old_tags, NEW, new_tags)
             )
 
-        elif new_tags != post.tags:
+        elif new_tags != old_tags:
             _replace_tags_line(post, new_tags)
 
     return new_tags
@@ -235,7 +239,36 @@ def _format_doc_string(function):
     return '\n'.join(doc_lines) + '\n'
 
 
+def _post_tags(post):
+    """Return the tags of a post, including special tags."""
+    tags = post.tags[:]
+    if post.is_draft:
+        tags.append('draft')
+
+    if post.is_private:
+        tags.append('private')
+
+    return tags
+
+def _posts_per_tag(site, include_special=True):
+    tags = site.posts_per_tag.copy()
+    if not include_special:
+        return tags
+
+    drafts = [post for post in site.all_posts if post.is_draft]
+    if len(drafts) > 0:
+        tags.update({'draft': drafts})
+
+    private = [post for post in site.all_posts if post.is_private]
+    if len(private) > 0:
+        tags.update({'private': private})
+
+    return tags
+
+
+
 class CommandTags(Command):
+
     """ Manage tags on the site.
 
     This plugin is inspired by `jtags <https://github.com/ttscoff/jtag>`_.


### PR DESCRIPTION
- `draft` and `private` tags can now be added and removed
- Other tags on posts which are marked draft or scheduled in future can be manipulated. 