### PR TITLE
Use a default directory for projects

### DIFF
--- a/v7/projectpages/README.md
+++ b/v7/projectpages/README.md
@@ -19,13 +19,14 @@ Why use a plugin?
 Usage
 -----
 
-1. Create an entry in `PAGES` for a special path, eg.
-
-       ("projects/*.rst", "projects", "project.tmpl")
-
-2. Create a setting named `PROJECT_PATH` pointing at the directory:
+1. `projects` directory is the default directory for projects.  You can change
+   this by setting `PROJECT_PATH` to a different value:
 
        PROJECT_PATH = 'projects'
+
+2. Create an entry in `PAGES` for a special path, eg.
+
+       ("projects/*.rst", "projects", "project.tmpl")
 
 3. Create project pages in reStructuredText (or any other supported markup language).
 4. Optionally create your own templates (some are provided with the plugin).

--- a/v7/projectpages/projectpages.py
+++ b/v7/projectpages/projectpages.py
@@ -40,10 +40,11 @@ class ProjectPages(Task):
 
     def set_site(self, site):
         site.register_path_handler('project', self.project_path)
-        site._GLOBAL_CONTEXT['project_path'] = site.config['PROJECT_PATH']
+        project_path = site.config.get('PROJECT_PATH', 'projects')
+        site._GLOBAL_CONTEXT['project_path'] = project_path
         site._GLOBAL_CONTEXT['project_index'] = {}
         for lang, tpath in site.config['TRANSLATIONS'].items():
-            site._GLOBAL_CONTEXT['project_index'][lang] = '/' + os.path.join(tpath, site.config['PROJECT_PATH'], site.config['INDEX_FILE']).replace('\\', '/')
+            site._GLOBAL_CONTEXT['project_index'][lang] = '/' + os.path.join(tpath, project_path, site.config['INDEX_FILE']).replace('\\', '/')
 
         # If you want to use breadcrumbs as provided by the crumbs template:
 


### PR DESCRIPTION
Installing the plugin and running any Nikola command before setting the
PROJECT_PATH causes errors.

Also, having a default value for projects is more convenient and in-line
with the defaults we have for posts and pages.