### PR TITLE
orgmode plugin: fix to macros.org (v. 6.0.1)

### DIFF
--- a/v6/orgmode/macros.org
+++ b/v6/orgmode/macros.org
@@ -3,14 +3,14 @@
 #+MACRO: gist #+HTML: <script src="https://gist.github.com/$1.js"></script>
 {{{gist(2395294)}}}
 
-#+MACRO: soundcloud #+HTML: <iframe width="$3" height="$2" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=http://api.soundcloud.com/tracks/$1"> </iframe>
+#+MACRO: soundcloud #+HTML: <iframe width="$3" height="$2" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https://api.soundcloud.com/tracks/$1"> </iframe>
 {{{soundcloud(31824842,240,320)}}}
 
-#+MACRO: soundcloud_playlist #+HTML: <iframe width="$3" height="$2" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=http://api.soundcloud.com/playlists/$1"> </iframe>
+#+MACRO: soundcloud_playlist #+HTML: <iframe width="$3" height="$2" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https://api.soundcloud.com/playlists/$1"> </iframe>
 {{{soundcloud_playlist(694081,800,400)}}}
 
-#+MACRO: vimeo #+HTML: <iframe src="http://player.vimeo.com/video/{vimeo_id}" width="$3" height="$2" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen> </iframe>
+#+MACRO: vimeo #+HTML: <iframe src="https://player.vimeo.com/video/$1" width="$3" height="$2" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen> </iframe>
 {{{vimeo(85360039,240,320)}}}
 
-#+MACRO: youtube #+HTML: <iframe width="$3" height="$2" src="http://www.youtube.com/embed/$1?rel=0&amp;hd=1&amp;wmode=transparent"></iframe>
+#+MACRO: youtube #+HTML: <iframe width="$3" height="$2" src="https://www.youtube.com/embed/$1?rel=0&amp;hd=1&amp;wmode=transparent"></iframe>
 {{{youtube(8N_tupPBtWQ,240,320)}}}

--- a/v6/orgmode/orgmode.plugin
+++ b/v6/orgmode/orgmode.plugin
@@ -4,7 +4,7 @@ Module = orgmode
 
 
 [Nikola]
-MinVersion = 6.0.1
+MinVersion = 6.0.0
 plugincategory = Compiler
 
 [Documentation]

--- a/v6/orgmode/orgmode.plugin
+++ b/v6/orgmode/orgmode.plugin
@@ -4,7 +4,7 @@ Module = orgmode
 
 
 [Nikola]
-MinVersion = 6.0.0
+MinVersion = 6.0.1
 plugincategory = Compiler
 
 [Documentation]

--- a/v6/orgmode/orgmode.plugin
+++ b/v6/orgmode/orgmode.plugin
@@ -9,7 +9,7 @@ plugincategory = Compiler
 
 [Documentation]
 Author = Puneeth Chaganti
-Version = 0.2
+Version = 0.3
 Website = http://plugins.getnikola.com/#orgmode
 Description = Compile org-mode markup into HTML using emacs.
 


### PR DESCRIPTION
Changed to use https instead of http.
This is needed for the vimeo macro on https pages otherways at least
Firefox blocks http content, on http it should not be an issue to use
https content.

All http:// have been replaced by https://.

Alos replace {vimeo id} with $1, to get correct vimeo url.