### PR TITLE
publication_list: enable multiple highlight authors

### DIFF
--- a/v7/publication_list/README.md
+++ b/v7/publication_list/README.md
@@ -24,7 +24,7 @@ The `publication-list` directive accepts multiple options.
   default is `papers`.
 
 * `:highlight_author:` indicates the author to highlight. Usually this is the
-  owner of the website. This can be a comma separated list if there are several
+  owner of the website. This can be a list of names separated by “;” if there are several
   optional names.
 
 * `:style:` indicates the style of the bibliography. All available styles are

--- a/v7/publication_list/README.md
+++ b/v7/publication_list/README.md
@@ -24,7 +24,8 @@ The `publication-list` directive accepts multiple options.
   default is `papers`.
 
 * `:highlight_author:` indicates the author to highlight. Usually this is the
-  owner of the website.
+  owner of the website. This can be a comma separated list if there are several
+  optional names.
 
 * `:style:` indicates the style of the bibliography. All available styles are
   provided by [Pybtex][]. You can see the [list of styles][] in the Pybtex

--- a/v7/publication_list/publication_list.py
+++ b/v7/publication_list/publication_list.py
@@ -69,7 +69,7 @@ class PublicationList(Directive):
         detail_page_dir = self.options.get('detail_page_dir', 'papers')
         highlight_authors = self.options.get('highlight_author', None)
         if highlight_authors:
-            highlight_authors = highlight_authors.split(',')
+            highlight_authors = highlight_authors.split(';')
         self.state.document.settings.record_dependencies.add(self.arguments[0])
 
         parser = Parser()

--- a/v7/publication_list/publication_list.py
+++ b/v7/publication_list/publication_list.py
@@ -67,7 +67,9 @@ class PublicationList(Directive):
         style = find_plugin('pybtex.style.formatting', self.options.get('style', 'unsrt'))()
         bibtex_dir = self.options.get('bibtex_dir', 'bibtex')
         detail_page_dir = self.options.get('detail_page_dir', 'papers')
-        highlight_author = self.options.get('highlight_author', None)
+        highlight_authors = self.options.get('highlight_author', None)
+        if highlight_authors:
+            highlight_authors = highlight_authors.split(',')
         self.state.document.settings.record_dependencies.add(self.arguments[0])
 
         parser = Parser()
@@ -100,8 +102,9 @@ class PublicationList(Directive):
                 html += '<h3>{}</h3>\n<ul>'.format(cur_year)
 
             pub_html = list(style.format_entries((entry,)))[0].text.render_as('html')
-            if highlight_author:  # highlight an author (usually oneself)
-                pub_html = pub_html.replace(highlight_author,
+            if highlight_authors:  # highlight one of several authors (usually oneself)
+                for highlight_author in highlight_authors:
+                    pub_html = pub_html.replace(highlight_author.strip(),
                                             '<strong>{}</strong>'.format(highlight_author), 1)
             html += '<li class="publication" style="padding-bottom: 1em;">' + pub_html
 

--- a/v7/publication_list/publication_list.py
+++ b/v7/publication_list/publication_list.py
@@ -104,8 +104,8 @@ class PublicationList(Directive):
             pub_html = list(style.format_entries((entry,)))[0].text.render_as('html')
             if highlight_authors:  # highlight one of several authors (usually oneself)
                 for highlight_author in highlight_authors:
-                    pub_html = pub_html.replace(highlight_author.strip(),
-                                            '<strong>{}</strong>'.format(highlight_author), 1)
+                    pub_html = pub_html.replace(
+                        highlight_author.strip(), '<strong>{}</strong>'.format(highlight_author), 1)
             html += '<li class="publication" style="padding-bottom: 1em;">' + pub_html
 
             extra_links = ""


### PR DESCRIPTION
Bibtex files (especially when pulled from different sources) often contain authors in different formats or spelling, for example I have entries with Jochen Schroeder, Jochen Schröder and just initials. This (small) change enables to specify a comma separated list of highlight authors which will be highlighted. I left the option name unchanged (highlight_author, singular) to not break existing sites.