### PR TITLE
Fixing .dep filename, and adjusting to getnikola/nikola#2547.

### DIFF
--- a/v7/wordpress_compiler/wordpress/wordpress.py
+++ b/v7/wordpress_compiler/wordpress/wordpress.py
@@ -195,7 +195,7 @@ class CompileWordpress(PageCompiler):
         return self.__formatData(source_data, context)
 
     def _get_dep_filename(self, post, lang):
-        return post.translated_base_path(lang) + '.dep'
+        return post.translated_base_path(lang) + '.wpdep'
 
     def get_extra_targets(self, post, lang, dest):
         return [self._get_dep_filename(post, lang)]
@@ -273,7 +273,7 @@ class CompileWordpress(PageCompiler):
             # Write result
             out_file.write(output)
             if post is None:
-                deps_path = dest + '.dep'
+                deps_path = dest + '.wpdep'
             else:
                 deps_path = self._get_dep_filename(post, lang)
             self._write_deps(context, deps_path)


### PR DESCRIPTION
This PR fixes a similar problem as in getnikola/nikola#2550 for the WordPress compiler, adjusts to the changes in PR getnikola/nikola#2547, and also provides a `compile()` function for newest Nikola. This is done (I think) in a backwards-compatible way, so it should work fine with older versions of Nikola.