### PR TITLE
Plugin to change previous/next post to reflect section indices instead of global index

### DIFF
--- a/v7/section_prevnext/README.md
+++ b/v7/section_prevnext/README.md
@@ -1,0 +1,11 @@
+This plugin changes the previous/next links below the posts to reflect the section index instead of the global index.
+This way, the sections of a blog behave more like independent subblogs.
+
+There is no configuration needed, but i recommend to replace the blog index by a static page to avoid confusing readers.
+This can be archived by setting INDEX\\_PATH to some subdirectory and adding a
+
+    PAGES = (
+      ("pages/*.md", "", "story.tmpl"),
+   	)
+
+and a corresponding index.md file.

--- a/v7/section_prevnext/README.md
+++ b/v7/section_prevnext/README.md
@@ -9,3 +9,5 @@ This can be archived by setting INDEX\\_PATH to some subdirectory and adding a
    	)
 
 and a corresponding index.md file.
+
+Depends on taxonomies introduced in Nikola 7.8.2 so be sure to use a recent version.

--- a/v7/section_prevnext/README.md
+++ b/v7/section_prevnext/README.md
@@ -2,12 +2,12 @@ This plugin changes the previous/next links below the posts to reflect the secti
 This way, the sections of a blog behave more like independent subblogs.
 
 There is no configuration needed, but i recommend to replace the blog index by a static page to avoid confusing readers.
-This can be archived by setting INDEX\\_PATH to some subdirectory and adding a
+This can be archived by setting INDEX\_PATH to some subdirectory, adding pages output to the root directory
 
     PAGES = (
       ("pages/*.md", "", "story.tmpl"),
    	)
 
-and a corresponding index.md file.
+and creating a corresponding pages/index.md file.
 
 Depends on taxonomies introduced in Nikola 7.8.2 so be sure to use a recent version.

--- a/v7/section_prevnext/section_prevnext.plugin
+++ b/v7/section_prevnext/section_prevnext.plugin
@@ -1,0 +1,12 @@
+[Core]
+name = section_prevnext
+module = section_prevnext
+
+[Documentation]
+author = Alexander Krimm
+version = 0.8
+website = https://getnikola.com/
+description = Sets next/previous link according to section index instead of global timeline
+
+[Nikola]
+PluginCategory = SignalHandler

--- a/v7/section_prevnext/section_prevnext.plugin
+++ b/v7/section_prevnext/section_prevnext.plugin
@@ -4,9 +4,10 @@ module = section_prevnext
 
 [Documentation]
 author = Alexander Krimm
-version = 0.8
-website = https://getnikola.com/
+version = 0.1
+website = https://plugins.getnikola.com/#section_prevnext
 description = Sets next/previous link according to section index instead of global timeline
 
 [Nikola]
 PluginCategory = SignalHandler
+MinVersion = 7.8.2

--- a/v7/section_prevnext/section_prevnext.py
+++ b/v7/section_prevnext/section_prevnext.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright © 2012-2017 Roberto Alsina and others.
+# Copyright © 2017 Alexander Krimm.
 
 # Permission is hereby granted, free of charge, to any
 # person obtaining a copy of this software and associated
@@ -24,7 +24,7 @@
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-"""Render the taxonomy overviews, classification pages and feeds."""
+"""Change navigation links below posts to next/previous post in section"""
 
 from __future__ import unicode_literals
 import blinker
@@ -33,7 +33,7 @@ from nikola.plugin_categories import SignalHandler
 
 
 class SectionNav(SignalHandler):
-    """Classify posts and pages by taxonomies."""
+    """Change navigation links below posts to next/previous post in section"""
 
     name = "section_prevnext"
 
@@ -45,7 +45,6 @@ class SectionNav(SignalHandler):
         for lang, langposts in site.posts_per_classification['section_index'].items():
             for section, sectionposts in langposts.items():
                 for i, p in enumerate(sectionposts[1:]):
-                    print(p.title)
                     p.next_post = sectionposts[i]
                 for i, p in enumerate(sectionposts[:-1]):
                     p.prev_post = sectionposts[i + 1]
@@ -55,5 +54,5 @@ class SectionNav(SignalHandler):
     def set_site(self, site):
         """Set site, which is a Nikola instance."""
         super(SectionNav, self).set_site(site)
-        # Add hook for after post scanning
+        # Add hook for after taxonomies_classifier has set site.posts_per_classification
         blinker.signal("taxonomies_classified").connect(self._set_navlinks)

--- a/v7/section_prevnext/section_prevnext.py
+++ b/v7/section_prevnext/section_prevnext.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+
+# Copyright © 2012-2017 Roberto Alsina and others.
+
+# Permission is hereby granted, free of charge, to any
+# person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the
+# Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the
+# Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice
+# shall be included in all copies or substantial portions of
+# the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+# PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+# OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""Render the taxonomy overviews, classification pages and feeds."""
+
+from __future__ import unicode_literals
+import blinker
+import functools
+import natsort
+import os
+import sys
+
+from collections import defaultdict
+
+from nikola.plugin_categories import SignalHandler
+from nikola import utils
+
+
+class SectionNav(SignalHandler):
+    """Classify posts and pages by taxonomies."""
+
+    name = "section_prevnext"
+
+    def _set_navlinks(self, site):
+        # Needed to avoid strange errors during tests
+        if site is not self.site:
+            return
+        # Update prev_post and next_post
+#        for lang, langposts in site.posts_per_classification['section_index'].iteritems():
+#            for section, sectionposts in langposts.iteritems():
+#                for i, p in enumerate(sectionposts[1:]):
+#                    print(p.title)
+#                    p.next_post = sectionposts[i]
+#                for i, p in enumerate(sectionposts[:-1]):
+#                    p.prev_post = sectionposts[i + 1]
+#                sectionposts[0].next_post = None
+#                sectionposts[-1].next_post = None
+
+    def set_site(self, site):
+        """Set site, which is a Nikola instance."""
+        super(SectionNav, self).set_site(site)
+        # Add hook for after post scanning
+        blinker.signal("scanned").connect(self._set_navlinks)

--- a/v7/section_prevnext/section_prevnext.py
+++ b/v7/section_prevnext/section_prevnext.py
@@ -30,8 +30,6 @@ from __future__ import unicode_literals
 import blinker
 
 from nikola.plugin_categories import SignalHandler
-#from nikola import utils
-
 
 class SectionNav(SignalHandler):
     """Classify posts and pages by taxonomies."""

--- a/v7/section_prevnext/section_prevnext.py
+++ b/v7/section_prevnext/section_prevnext.py
@@ -28,15 +28,9 @@
 
 from __future__ import unicode_literals
 import blinker
-import functools
-import natsort
-import os
-import sys
-
-from collections import defaultdict
 
 from nikola.plugin_categories import SignalHandler
-from nikola import utils
+#from nikola import utils
 
 
 class SectionNav(SignalHandler):
@@ -49,18 +43,18 @@ class SectionNav(SignalHandler):
         if site is not self.site:
             return
         # Update prev_post and next_post
-#        for lang, langposts in site.posts_per_classification['section_index'].iteritems():
-#            for section, sectionposts in langposts.iteritems():
-#                for i, p in enumerate(sectionposts[1:]):
-#                    print(p.title)
-#                    p.next_post = sectionposts[i]
-#                for i, p in enumerate(sectionposts[:-1]):
-#                    p.prev_post = sectionposts[i + 1]
-#                sectionposts[0].next_post = None
-#                sectionposts[-1].next_post = None
+        for lang, langposts in site.posts_per_classification['section_index'].items():
+            for section, sectionposts in langposts.items():
+                for i, p in enumerate(sectionposts[1:]):
+                    print(p.title)
+                    p.next_post = sectionposts[i]
+                for i, p in enumerate(sectionposts[:-1]):
+                    p.prev_post = sectionposts[i + 1]
+                sectionposts[0].next_post = None
+                sectionposts[-1].prev_post = None
 
     def set_site(self, site):
         """Set site, which is a Nikola instance."""
         super(SectionNav, self).set_site(site)
         # Add hook for after post scanning
-        blinker.signal("scanned").connect(self._set_navlinks)
+        blinker.signal("taxonomies_classified").connect(self._set_navlinks)

--- a/v7/section_prevnext/section_prevnext.py
+++ b/v7/section_prevnext/section_prevnext.py
@@ -31,6 +31,7 @@ import blinker
 
 from nikola.plugin_categories import SignalHandler
 
+
 class SectionNav(SignalHandler):
     """Classify posts and pages by taxonomies."""
 


### PR DESCRIPTION
Plugin to solve getnikola/nikola#2625.

Subscribe to the 'taxonomies_classified' signal and upon receiving it update next_post and previous_post for every post to its successor/predecessor in it's corresponding section.