### PR TITLE
Fix #221 -- add dependencies in pkgindex_compiler

### DIFF
--- a/v7/pkgindex/pkgindex.plugin
+++ b/v7/pkgindex/pkgindex.plugin
@@ -8,6 +8,6 @@ MinVersion = 7.8.2
 
 [Documentation]
 Author = Chris Warrick
-Version = 0.2.1
+Version = 0.2.2
 Website = https://plugins.getnikola.com/
 Description = Generate package indexes (meta-plugin)

--- a/v7/pkgindex_compiler/pkgindex_compiler.plugin
+++ b/v7/pkgindex_compiler/pkgindex_compiler.plugin
@@ -8,6 +8,6 @@ MinVersion = 7.8.1+
 
 [Documentation]
 Author = Chris Warrick, Roberto Alsina
-Version = 0.2.1
+Version = 0.2.2
 Website = https://plugins.getnikola.com/
 Description = Compile pages in package indexes

--- a/v7/pkgindex_compiler/pkgindex_compiler.py
+++ b/v7/pkgindex_compiler/pkgindex_compiler.py
@@ -66,6 +66,7 @@ def parse_plugin_file(post, pkg_dir, config):
     reqplugins = os.path.join(pkg_dir, 'requirements-plugins.txt')
 
     if os.path.exists(ini):
+        post.add_dependency(ini)
         try:
             c = configparser.ConfigParser()
             c.read(ini)
@@ -107,6 +108,7 @@ def parse_plugin_file(post, pkg_dir, config):
                          'directory.'.format(plugin))
 
     if os.path.exists(conf_sample):
+        post.add_dependency(conf_sample)
         with io.open(conf_sample, 'r', encoding='utf-8') as f:
             data['confpy'] = pygments.highlight(
                 f.read(),
@@ -115,12 +117,14 @@ def parse_plugin_file(post, pkg_dir, config):
         data['confpy'] = None
 
     if os.path.exists(reqpy):
+        post.add_dependency(reqpy)
         with io.open(reqpy, 'r', encoding='utf-8') as f:
             data['pyreqs'] = f.readlines()
     else:
         data['pyreqs'] = []
 
     if os.path.exists(reqnonpy):
+        post.add_dependency(reqnonpy)
         with io.open(reqnonpy, 'r', encoding='utf-8') as f:
             r = f.readlines()
 
@@ -129,6 +133,7 @@ def parse_plugin_file(post, pkg_dir, config):
         data['nonpyreqs'] = []
 
     if os.path.exists(reqplugins):
+        post.add_dependency(reqplugins)
         with io.open(reqplugins, 'r', encoding='utf-8') as f:
             data['pluginreqs'] = f.readlines()
     else:
@@ -153,6 +158,7 @@ def parse_theme_info(post, pkg_dir, config):
     parent = os.path.join(pkg_dir, 'parent')
 
     if os.path.exists(conf_sample):
+        post.add_dependency(conf_sample)
         with io.open(conf_sample, 'r', encoding='utf-8') as f:
             data['confpy'] = pygments.highlight(
                 f.read(),
@@ -161,12 +167,14 @@ def parse_theme_info(post, pkg_dir, config):
         data['confpy'] = None
 
     if os.path.exists(engine):
+        post.add_dependency(engine)
         with io.open(engine, 'r', encoding='utf-8') as f:
             data['engine'] = f.read().strip()
     else:
         data['engine'] = 'mako'
 
     if os.path.exists(parent):
+        post.add_dependency(parent)
         with io.open(parent, 'r', encoding='utf-8') as f:
             data['parent'] = f.read().strip()
     elif theme == 'base':

--- a/v7/pkgindex_scan/pkgindex_scan.plugin
+++ b/v7/pkgindex_scan/pkgindex_scan.plugin
@@ -8,6 +8,6 @@ MinVersion = 7.8.1+
 
 [Documentation]
 Author = Chris Warrick
-Version = 0.2.1
+Version = 0.2.2
 Website = https://plugins.getnikola.com/
 Description = Scan packages for package indexes

--- a/v7/pkgindex_zip/pkgindex_zip.plugin
+++ b/v7/pkgindex_zip/pkgindex_zip.plugin
@@ -8,6 +8,6 @@ MinVersion = 7.8.1+
 
 [Documentation]
 Author = Chris Warrick
-Version = 0.2.1
+Version = 0.2.2
 Website = https://plugins.getnikola.com/
 Description = Generate ZIP (and JSON) files for package indexes


### PR DESCRIPTION
I’m using `add='both'` implicitly, because some of those files do not appear in `cache/*.html`.