### PR TITLE
Add some site statistics to global context

### DIFF
--- a/v7/site_stats/README.md
+++ b/v7/site_stats/README.md
@@ -1,0 +1,42 @@
+This plugin computes some summary statistics and inserts them into the global context.
+
+## Installation
+
+From within a nikola site directory:
+
+```
+$ nikola plugin -i site_stats
+```
+
+## Usage
+
+After installation, the following keys/values are accessible in `site.GLOBAL_CONTEXT`:
+
+* `post_count`: the number of posts in the site
+* `cat_count`: the number of categories in the site
+* `tag_count`: the number of tags in the site.
+
+Nothing visible will happen, though, unless you access this data within a template.  
+For instance, with `mako` templates you can insert a block
+
+```html
+<%def name="html_site_statistics()">
+    <div class="stats">
+        <div class="line">
+            <span class="counter">${post_count}</span>
+            <span class="caption">Posts</span>
+        </div>
+        <div class="line">
+            <span class="counter">${category_count}</span>
+            <span class="caption">Categories</span>
+        </div>
+        <div class="line">
+            <span class="counter">${tag_count}</span>
+            <span class="caption">Tags</span>
+        </div>
+    </div>
+</%def>
+```
+
+Then put `${html_site_statistics()}` wherever you want it to go.
+

--- a/v7/site_stats/README.md
+++ b/v7/site_stats/README.md
@@ -40,3 +40,9 @@ For instance, with `mako` templates you can insert a block
 
 Then put `${html_site_statistics()}` wherever you want it to go.
 
+## Related
+
+The [`sidebar`](https://github.com/getnikola/plugins/tree/master/v7/sidebar) plugin
+has this same functionality and more.  It provides templates and generates an HTML 
+fragment that can be included into any page.  Either way will require some template
+hacking to see the content on your pages.

--- a/v7/site_stats/site_stats.plugin
+++ b/v7/site_stats/site_stats.plugin
@@ -4,8 +4,8 @@ module = site_stats
 
 [Documentation]
 author = Matthew Leingang
-version = 0.1
-website = https://matthewleingang.com/
+version = 1.0
+website = https://github.com/leingang/nikola-plugins/tree/site-stats/v7/sidebar
 description = insert a count of posts, tags, and categories into global context.
 
 [Nikola]

--- a/v7/site_stats/site_stats.plugin
+++ b/v7/site_stats/site_stats.plugin
@@ -1,0 +1,13 @@
+[Core]
+name = site_stats
+module = site_stats
+
+[Documentation]
+author = Matthew Leingang
+version = 0.1
+website = https://matthewleingang.com/
+description = insert a count of posts, tags, and categories into global context.
+
+[Nikola]
+plugincategory = Config
+MinVersion = 7.7.3+

--- a/v7/site_stats/site_stats.py
+++ b/v7/site_stats/site_stats.py
@@ -1,0 +1,40 @@
+"""A Nikola plugin to compute and add site statistics to global context."""
+
+import logbook
+from nikola.plugin_categories import ConfigPlugin
+from nikola import utils
+
+
+LOGGER = utils.get_logger("site_stats", utils.STDERR_HANDLER)
+
+
+class SiteStats(ConfigPlugin):
+    """Add site statistics to global context"""
+
+    name = "site_stats"
+    debug = False
+
+    def set_site(self, site):
+        site.scan_posts()
+        if self.debug:
+            for handler in LOGGER.handlers:
+                handler.level = logbook.DEBUG
+        self.set_post_count(site)
+        self.set_category_count(site)
+        self.set_tag_count(site)
+        super(SiteStats, self).set_site(site)
+
+    def set_post_count(self, site):
+        post_count = len(site.posts)
+        LOGGER.debug('post_count: %s' % post_count)
+        site.GLOBAL_CONTEXT['post_count'] = post_count
+
+    def set_tag_count(self, site):
+        tag_count = len(site.posts_per_tag)
+        LOGGER.debug('tag_count: %s' % tag_count)
+        site.GLOBAL_CONTEXT['tag_count'] = tag_count
+
+    def set_category_count(self, site):
+        category_count = len(site.posts_per_category)
+        LOGGER.debug('category_count: %s' % category_count)
+        site.GLOBAL_CONTEXT['category_count'] = category_count


### PR DESCRIPTION
This is a tiny plugin I wrote to add some keys to the global context.

* `post_count`: the number of posts in the site
* `cat_count`: the number of categories in the site
* `tag_count`: the number of tags in the site.

