### PR TITLE
Making plugins basically compatible (loghandlers is gone).

### DIFF
--- a/v7/deploy_hooks/deploy_hooks.py
+++ b/v7/deploy_hooks/deploy_hooks.py
@@ -30,7 +30,7 @@ import sys
 from blinker import signal
 
 from nikola.plugin_categories import SignalHandler
-from nikola.utils import get_logger
+from nikola.utils import get_logger, STDERR_HANDLER
 
 
 class DeployHooks(SignalHandler):
@@ -58,7 +58,7 @@ class DeployHooks(SignalHandler):
 
     def set_site(self, site):
         self.site = site
-        self.logger = get_logger(self.name, self.site.loghandlers)
+        self.logger = get_logger(self.name, STDERR_HANDLER)
 
         ready = signal('deployed')
         ready.connect(self.run_hooks)

--- a/v7/iarchiver/iarchiver.py
+++ b/v7/iarchiver/iarchiver.py
@@ -33,7 +33,7 @@ import time
 import dateutil.tz
 
 from nikola.plugin_categories import Command
-from nikola.utils import get_logger
+from nikola.utils import get_logger, STDERR_HANDLER
 
 if sys.version_info[0] == 2:
     import robotparser as robotparser
@@ -56,7 +56,7 @@ class Iarchiver(Command):
 
     def _execute(self, command, args):
 
-        self.logger = get_logger('iarchiver', self.site.loghandlers)
+        self.logger = get_logger('iarchiver', STDERR_HANDLER)
 
         """ /robots.txt must be in root, so this use of urljoin() is intentional """
         iatestbot = robotparser.RobotFileParser(urljoin(self.site.config['SITE_URL'], "/robots.txt"))

--- a/v7/ping/ping.py
+++ b/v7/ping/ping.py
@@ -31,7 +31,7 @@ import os
 import sys
 
 from nikola.plugin_categories import Command
-from nikola.utils import get_logger
+from nikola.utils import get_logger, STDERR_HANDLER
 
 
 class Ping(Command):
@@ -45,7 +45,7 @@ class Ping(Command):
 
     def _execute(self, command, args):
 
-        self.logger = get_logger('ping', self.site.loghandlers)
+        self.logger = get_logger('ping', STDERR_HANDLER)
 
         timestamp_path = os.path.join(self.site.config['CACHE_FOLDER'], 'lastping')
         new_ping = datetime.utcnow()

--- a/v7/sass/sass.py
+++ b/v7/sass/sass.py
@@ -44,7 +44,7 @@ class BuildSass(Task):
 
     def gen_tasks(self):
         """Generate CSS out of Sass sources."""
-        self.logger = utils.get_logger('build_sass', self.site.loghandlers)
+        self.logger = utils.get_logger('build_sass', utils.STDERR_HANDLER)
         self.compiler_name = self.site.config['SASS_COMPILER']
         self.compiler_options = self.site.config['SASS_OPTIONS']
 

--- a/v7/speechsynthesizednetcast/speechsynthesizednetcast.py
+++ b/v7/speechsynthesizednetcast/speechsynthesizednetcast.py
@@ -61,7 +61,7 @@ class SpeechSynthesizedNetcast(Task):
 
     def gen_tasks(self):
 
-        self.logger = utils.get_logger('speechsynthesizednetcast', self.site.loghandlers)
+        self.logger = utils.get_logger('speechsynthesizednetcast', utils.STDERR_HANDLER)
 
         # Deps and config
         kw = {

--- a/v7/upgrade_metadata/upgrade_metadata.py
+++ b/v7/upgrade_metadata/upgrade_metadata.py
@@ -50,7 +50,7 @@ class UpgradeMetadata(Command):
     fields = ('title', 'slug', 'date', 'tags', 'link', 'description', 'type')
 
     def _execute(self, options, args):
-        L = utils.get_logger('upgrade_metadata', self.site.loghandlers)
+        L = utils.get_logger('upgrade_metadata', utils.STDERR_HANDLER)
         nikola.post._UPGRADE_METADATA_ADVERTISED = True
 
         # scan posts

--- a/v7/vcs/vcs.py
+++ b/v7/vcs/vcs.py
@@ -34,7 +34,7 @@ except ImportError:
     workdir = None
 
 from nikola.plugin_categories import Command
-from nikola.utils import get_logger, req_missing
+from nikola.utils import get_logger, req_missing, STDERR_HANDLER
 
 
 def get_path_list(path):
@@ -59,7 +59,7 @@ class CommandVCS(Command):
     def _execute(self, options, args):
         if workdir is None:
             req_missing(['anyvc'], 'use the anyvc plugin')
-        logger = get_logger('vcs', self.site.loghandlers)
+        logger = get_logger('vcs', STDERR_HANDLER)
         self.site.scan_posts()
 
         repo_path = local('.')


### PR DESCRIPTION
`site.loghandlers` is gone. (Adjusting to this should work with v7 as well, most plugins didn't use it anyway.)

Maybe some more changes are needed as well?