### PR TITLE
Localsearch non root context

### DIFF
--- a/v7/localsearch/conf.py.sample
+++ b/v7/localsearch/conf.py.sample
@@ -32,17 +32,22 @@ BODY_END = """
   </div>
 </div>
 <script>
+"""
+BODY_END += """
+    var siteUrl = "{siteUrl}"
+""".format(siteUrl = SITE_URL)
+BODY_END += """
 $(document).ready(function() {
     $.when(
-        $.getScript( "/assets/js/tipuesearch_set.js" ),
-        $.getScript( "/assets/js/tipuesearch.js" ),
+        $.getScript( siteUrl + "/assets/js/tipuesearch_set.js" ),
+        $.getScript( siteUrl + "/assets/js/tipuesearch.js" ),
         $.Deferred(function( deferred ){
             $( deferred.resolve );
         })
     ).done(function() {
         $('#tipue_search_input').tipuesearch({
             'mode': 'json',
-            'contentLocation': '/assets/js/tipuesearch_content.json'
+            'contentLocation': siteUrl + '/assets/js/tipuesearch_content.json'
         });
         $('#tipue_search_input').keyup(function (e) {
             if (e.keyCode == 13) {

--- a/v7/localsearch/conf.py.sample
+++ b/v7/localsearch/conf.py.sample
@@ -32,11 +32,7 @@ BODY_END = """
   </div>
 </div>
 <script>
-"""
-BODY_END += """
-    var siteUrl = "{siteUrl}"
-""".format(siteUrl = SITE_URL)
-BODY_END += """
+var siteUrl = '""" + SITE_URL + """'
 $(document).ready(function() {
     $.when(
         $.getScript( siteUrl + "/assets/js/tipuesearch_set.js" ),

--- a/v7/localsearch/conf.py.sample
+++ b/v7/localsearch/conf.py.sample
@@ -7,6 +7,10 @@ SEARCH_FORM = """
 <input type="text" id="tipue_search_input" class="form-control" placeholder="Search">
 </span>"""
 
+EXTRA_HEAD_DATA = """
+<link rel="stylesheet" type="text/css" href="/assets/css/tipuesearch.css">
+"""
+
 BODY_END = """
 <!-- Modal -->
 <div id="search-results" class="modal fade" role="dialog" style="height: 80%;">
@@ -48,8 +52,4 @@ $(document).ready(function() {
     });
 });
 </script>
-"""
-
-EXTRA_HEAD_DATA = """
-<link rel="stylesheet" type="text/css" href="/assets/css/tipuesearch.css">
 """

--- a/v7/localsearch/conf.py.sample
+++ b/v7/localsearch/conf.py.sample
@@ -1,6 +1,7 @@
 # This is an example that works well with Nikola's default Bootstrap3 theme.
 # It displays the search field in the navigation bar, and the results
 # in a modal dialog.
+import json
 
 SEARCH_FORM = """
 <span class="navbar-form navbar-left">
@@ -32,7 +33,7 @@ BODY_END = """
   </div>
 </div>
 <script>
-var siteUrl = '""" + SITE_URL + """'
+var siteUrl = """ + json.dumps(SITE_URL) + """
 $(document).ready(function() {
     $.when(
         $.getScript( siteUrl + "/assets/js/tipuesearch_set.js" ),


### PR DESCRIPTION
Fixes #242.

Please note: I reordered conf.py.sample to match the ordering within conf.py. This is not required for #242.

Related to #242: It is important to prepend the SITE_URL when loading via javascript. My python skills
are very low. I didn't succeed in adding a `.format()` to the complete BODY_END, maybe since there are
extra brackets within the string. So I splitted BODY_END into parts and used `format()` only on the middle
part.