### PR TITLE
use <s> tag instead of deprecated <strike>

### DIFF
--- a/v7/html_roles/README.md
+++ b/v7/html_roles/README.md
@@ -4,7 +4,7 @@ Currently supported:
 
 * `del` - [Deleted text](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/del)
 * `ins` - [Inserted text](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ins)
-* `s` - [Strikethrough](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s)
+* `strike` - [Strikethrough](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s)
 
 ### Usage
 

--- a/v7/html_roles/html_roles.py
+++ b/v7/html_roles/html_roles.py
@@ -30,7 +30,7 @@ from docutils.parsers.rst import roles
 from nikola.plugin_categories import RestExtension
 
 TAGS = {
-    's': 's',
+    'strike': 's',
     'del': 'del',
     'ins': 'ins',
 }


### PR DESCRIPTION
Not a big thing, but it looks as `<strike>` tag is deprecated and obsolete, so new sites are recommended to use `<s>` tag instead...