### PR TITLE
static_comments: call mako filters inside a function

### DIFF
--- a/v7/static_comments/templates/mako/static_comments_helper.tmpl
+++ b/v7/static_comments/templates/mako/static_comments_helper.tmpl
@@ -12,8 +12,15 @@
         <div class="comment-header">
           <a name="comment-${ comment.id }"></a>
           % if comment.author is not None:
+            <%def name="author()" buffered="True">
+              % if comment.author_url is not None:
+                <a href="${ comment.author_url|h }">${ comment.author|h }</a>
+              % else:
+                ${ comment.author|h }
+              % endif
+            </%def>
             ${ messages("{0} wrote on {1}:", lang).format(
-              '<span class="author">' + ('<a href="{0}">{1}</a>'.format(comment.author_url|h, comment.author|h) if comment.author_url is not None else (comment.author|h)) + '</span>',
+              '<span class="author">' + author() + '</span>',
               '<span class="date">' + comment.formatted_date(date_format) + '</span>'
             ) }
           % endif

--- a/v8/static_comments/templates/mako/static_comments_helper.tmpl
+++ b/v8/static_comments/templates/mako/static_comments_helper.tmpl
@@ -12,8 +12,15 @@
         <div class="comment-header">
           <a name="comment-${ comment.id }"></a>
           % if comment.author is not None:
+            <%def name="author()" buffered="True">
+              % if comment.author_url is not None:
+                <a href="${ comment.author_url|h }">${ comment.author|h }</a>
+              % else:
+                ${ comment.author|h }
+              % endif
+            </%def>
             ${ messages("{0} wrote on {1}:", lang).format(
-              '<span class="author">' + ('<a href="{0}">{1}</a>'.format(comment.author_url|h, comment.author|h) if comment.author_url is not None else (comment.author|h)) + '</span>',
+              '<span class="author">' + author() + '</span>',
               '<span class="date">' + comment.formatted_date(date_format) + '</span>'
             ) }
           % endif


### PR DESCRIPTION
you can't call mako filters inside python code, you'll get an error like
this instead:

        '<span class="author">' + ('<a href="{0}">{1}</a>'.format(comment.author_url|h, comment.author|h) if comment.author_url is not None else (comment.author|h)) + '</span>',
    TypeError: unsupported operand type(s) for |: 'str' and 'Undefined'

move the author line generation into an mako function, which again can
use mako filters