### PR TITLE
Make german_slugify plugin v8 compatible

### DIFF
--- a/v8/german_slugify/README.md
+++ b/v8/german_slugify/README.md
@@ -1,0 +1,7 @@
+This plugin converts German umlauts ä, ö, ü, ß and their upper-case
+variants to ae, oe, ue and ss when slugifying. This translation is
+only done for languages detected as German, other languages are not
+affected.
+
+You currently have to modify the plugin itself to override the
+language detection.

--- a/v8/german_slugify/german_slugify.plugin
+++ b/v8/german_slugify/german_slugify.plugin
@@ -1,0 +1,11 @@
+[Core]
+Name = german_slugify
+Module = german_slugify
+
+[Nikola]
+PluginCategory = SignalHandler
+
+[Documentation]
+Author = Felix Fontein
+Version = 1.0
+Description = Converts German umlauts ä, ö, ü, ß to ae, oe, ue, ss while slugifying.

--- a/v8/german_slugify/german_slugify.py
+++ b/v8/german_slugify/german_slugify.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+
+from nikola.plugin_categories import SignalHandler
+from nikola import utils
+
+
+def _needs_german_slugifying_rules(lang, locale):
+    """Checks whether the given language name with corresponding locale needs German slugifying rules."""
+    if locale.split('_')[0] in {'de', 'gsw'}:  # German and Allemanic German
+        return True
+    if lang in {'de',
+                'de_at', 'de_ch', 'de_de',
+                'de-at', 'de-ch', 'de-de',
+                'atde', 'chde', 'dede'}:
+        return True
+    return False
+
+
+class GermanSlugify(SignalHandler):  # Could also be any other plugin type which is initialized early enough.
+    def set_site(self, site):
+        super(GermanSlugify, self).set_site(site)
+
+        # First determine languages which belong to German locales
+        self.german_languages = set()
+        for lang, loc in utils.LocaleBorg.locales.items():
+            if _needs_german_slugifying_rules(lang, loc):
+                self.german_languages.add(lang)
+        if len(self.german_languages) > 0:
+            utils.LOGGER.debug("Using German slugifying rules for the following languages: {0}".format(', '.join(sorted(self.german_languages))))
+        else:
+            utils.LOGGER.debug("Not using German slugifying rules.")
+
+        # Store old slugify method
+        self.old_slugify = utils.slugify
+
+        # Define new slugify method
+        def new_slugify(value, lang=None, force=False):
+            if lang is not None and lang in self.german_languages:
+                if not isinstance(value, utils.unicode_str):
+                    raise ValueError("Not a unicode object: {0}".format(value))
+                value = value.replace('ä', 'ae').replace('ö', 'oe').replace('ü', 'ue').replace('ß', 'ss')
+                value = value.replace('Ä', 'ae').replace('Ö', 'oe').replace('Ü', 'ue')
+            return self.old_slugify(value, lang=lang, force=force)
+
+        # Setting it as utils.slugify
+        utils.slugify = new_slugify
+
+        # Note that we do not replace utils.unslugify as ae,oe,ue,ss cannot
+        # be substitued by ä,ö,ü,ß in all cases.

--- a/v8/german_slugify/german_slugify.py
+++ b/v8/german_slugify/german_slugify.py
@@ -22,7 +22,8 @@ class GermanSlugify(SignalHandler):  # Could also be any other plugin type which
 
         # First determine languages which belong to German locales
         self.german_languages = set()
-        for lang, loc in utils.LocaleBorg.locales.items():
+        for lang in site.config['TRANSLATIONS'].keys():
+            loc = utils.LocaleBorg.locales.get(lang, lang)
             if _needs_german_slugifying_rules(lang, loc):
                 self.german_languages.add(lang)
         if len(self.german_languages) > 0:


### PR DESCRIPTION
`LocaleBorg.locales` doesn't come prefilled with all the blog's languages anymore.