### PR TITLE
make `jsonfeed` work in v8

### DIFF
--- a/v7/jsonfeed/jsonfeed.py
+++ b/v7/jsonfeed/jsonfeed.py
@@ -62,7 +62,7 @@ class JSONFeed(Task):
             'feed_links_append_query': self.site.config['FEED_LINKS_APPEND_QUERY'],
             'feed_length': self.site.config['FEED_LENGTH'],
             'feed_plain': self.site.config['FEED_PLAIN'],
-            'feed_previewimage': self.site.config['FEED_PREVIEWIMAGE'],
+            'feed_previewimage': self.site.config.get('FEED_PREVIEWIMAGE', True),
             'feed_read_more_link': self.site.config['FEED_READ_MORE_LINK'],
             'feed_teasers': self.site.config['FEED_TEASERS'],
             'jsonfeed_append_links': self.site.config.get('JSONFEED_APPEND_LINKS', True),
@@ -70,9 +70,6 @@ class JSONFeed(Task):
             'blog_title': self.site.config['BLOG_TITLE'],
             'blog_description': self.site.config['BLOG_DESCRIPTION'],
             'blog_author': self.site.config['BLOG_AUTHOR'],
-            'tag_pages_titles': self.site.config['TAG_PAGES_TITLES'],
-            'category_pages_titles': self.site.config['CATEGORY_PAGES_TITLES'],
-            'posts_section_title': self.site.config['POSTS_SECTION_TITLE'],
             'archives_are_indexes': self.site.config['ARCHIVES_ARE_INDEXES'],
         }
 

--- a/v7/jsonfeed/jsonfeed.py
+++ b/v7/jsonfeed/jsonfeed.py
@@ -99,7 +99,8 @@ class JSONFeed(Task):
                                           timeline, feed_url, output_name)
 
             for classification_name, path_handler in self.supported_taxonomies.items():
-                taxonomy = self.site.taxonomy_plugins[classification_name]
+                taxonomy = self.site.taxonomy_plugins.get(classification_name)
+                if not taxonomy: continue
 
                 if classification_name == "archive" and not self.kw['archives_are_indexes']:
                     continue


### PR DESCRIPTION
I don't know if I am supposed to copy this to `v8/`, but these are the mimimum changes required for jsonfeed to not break a v8 installation:
- removed unused config entries that have been deprecated/renamed
- add a default for the one config entry that is actually used

I don't know if it makes jsonfeed **work**, I just know that it doesn't prevent nikola from starting.