### PR TITLE
Request to merge postcast plugin for nikola 8

### DIFF
--- a/v8/postcast/README.md
+++ b/v8/postcast/README.md
@@ -47,12 +47,36 @@ subscription by popular podcast applications.
 Other configuration options are available. For more information, see
 `conf.py.sample`.
 
-- Posts selected for incorporation into a feed should have `enclosure`
-  metadata linking to the audio file to be used. This file needs to be
-  available as part of the site source, as it will be directly
-  inspected for attributes as part of the feed generation.
 
-  .. enclosure: episode.mp3
+## Peta fields
 
-Other per-post metadata may also be provided. For more information,
-see `post.rst.sample`.
+- **category** - the post category is used to select posts for the
+    feed
+
+- **tag** - post tags are used to select posts for the feed
+
+- **author** - the post author is used to identify the author of the
+    episode in the feed
+
+- **itunes_author** - an explicit author for the episode can be
+    specified if it differs from the post author
+
+- **itunes_summary** - an explicit summary can be provided for the
+    episode; otherwise, the body of the post will be used
+
+- **itunes_image** - episode art
+
+- **enclosure** - the audio file (usually .mp3 or .ogg) to be
+    distributed
+
+- **itunes_duration** - the real-time length of the audio file; used
+    to provide this information to applications before the file has
+    been downloaded
+
+- **itunes_subtitle** - a short description that provides general
+    information about the episode
+
+- **itunes_explicit** - a boolean expressing whether the episode
+    contains explicit content; overrides POSTCAST_ITUNES_EXPLICIT
+
+For more information, see `post.rst.sample`.

--- a/v8/postcast/README.md
+++ b/v8/postcast/README.md
@@ -1,1 +1,58 @@
-Generates podcast/netcast RSS feeds from posts
+# postcast plugin for Nikola
+
+Generates podcast/netcast RSS feeds from posts. It is originally based
+on the speechsynthesizednetcast copyright © 2013–2014 Daniel
+Aleksandersen and others.
+
+**LIVE DEMO:** https://civilfritz.net/casts/gameolder.xml
+
+
+## Why use this plugin?
+
+Nikola is, among other things, a site generator capable of creating
+aggregation feeds from a collection of posts. These posts can be
+associated with metadata. By adding `enclosure` and other metadata to
+a post, these posts effectively become entries in a podcast-style rss
+feed suitable for publication with popular podcast platforms and
+subscription by popular podcast applications.
+
+
+## Usage
+
+- `casts` directory is the location in `output` where your cast feeds
+  will be generated. You can change this by setting `POSTCAST_PATH`.
+
+      POSTCAST_PATH = 'casts'
+
+- By default, no postcast feeds are generated; one feed will be
+  generated for each entry in the `POSTCASTS` list.
+
+      POSTCASTS = ['mycast']
+
+- Each cast feed can be associated with a Nikola category. Only posts
+  in that category will be incorporated into the feed.
+
+      POSTCAST_CATEGORY = {
+          'mycast': 'cat_mycast',
+      }
+
+- Each cast feed can further (or in stead) be associated with a list
+  of tags. Only posts with *all* of the tags in the list will be
+  incorporated into the feed.
+
+      POSTCAST_TAGS = {
+          'mycast': ['mycast-episode'],
+      }
+
+Other configuration options are available. For more information, see
+`conf.py.sample`.
+
+- Posts selected for incorporation into a feed should have `enclosure`
+  metadata linking to the audio file to be used. This file needs to be
+  available as part of the site source, as it will be directly
+  inspected for attributes as part of the feed generation.
+
+  .. enclosure: episode.mp3
+
+Other per-post metadata may also be provided. For more information,
+see `post.rst.sample`.

--- a/v8/postcast/README.md
+++ b/v8/postcast/README.md
@@ -1,0 +1,1 @@
+Generates podcast/netcast RSS feeds from posts

--- a/v8/postcast/README.md
+++ b/v8/postcast/README.md
@@ -48,7 +48,7 @@ Other configuration options are available. For more information, see
 `conf.py.sample`.
 
 
-## Peta fields
+## Post meta fields
 
 - **category** - the post category is used to select posts for the
     feed

--- a/v8/postcast/conf.py.sample
+++ b/v8/postcast/conf.py.sample
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+
+# example settings for postcast nikola plugin
+
+# Path for where postcast feeds will be generated.
+
+# Final locations are:
+# output / TRANSLATION[lang] / POSTCAST_PATH / postcast.xml
+# POSTCAST_PATH = 'casts'
+# POSTCASTS = ['postcast']
+
+# Filter posts to be included in a feed by category. The default is
+# all posts. Specifying a category for the '' feed will result in all
+# feeds being filtered by that category.
+# POSTCAST_CATEGORY = {
+#     '': 'postcast',
+# }
+
+# Filter posts to be included in a feed with a list of tags. The
+# default is all posts. Specifying tags for the '' feed will result in
+# all feeds being filtered by those tags.
+# POSTCAST_TAGS = {
+#     '': ['podcast-episode'],
+# }
+
+# Provide an image to be assocated with the feed. The default is no
+# image. Specifying an image for the '' feed will result in all feeds
+# being associated with that image.
+# POSTCAST_ITUNES_IMAGE = {
+#     '': 'images/postcast-logo.png',
+# }
+
+# Indicate whether each feed contains explicit content. The default is
+# undefined. Specifying a value for the '' feed will result in all
+# feeds being marked.
+# POSTCAST_ITUNES_EXPLICIT = {
+#     '': False,
+# }
+
+# Provide a list of iTunes categories to be associated with the
+# feed. The default is undefined. Specifying categories for the ''
+# feed will result in all feeds being categorized the same.
+# POSTCAST_ITUNES_CATEGORIES = {
+#     '': [
+#         ('Arts', ('Design', 'Literature', 'Visual Arts')),
+#         ('Games & Hobbies', ('Video Games', )),
+#         ('Religion & Spirituality', ('Christianity', )),
+#         ('Technology', ),
+#         ('Society & Culture', ('Philosophy', )),
+#     ],
+# }

--- a/v8/postcast/conf.py.sample
+++ b/v8/postcast/conf.py.sample
@@ -20,7 +20,7 @@
 # default is all posts. Specifying tags for the '' feed will result in
 # all feeds being filtered by those tags.
 # POSTCAST_TAGS = {
-#     '': ['podcast-episode'],
+#     '': ['postcast-episode'],
 # }
 
 # Provide an image to be assocated with the feed. The default is no

--- a/v8/postcast/post.rst.sample
+++ b/v8/postcast/post.rst.sample
@@ -1,0 +1,8 @@
+.. enclosure: episode.mp3
+.. author: Jonathon Anderson
+.. itunes_author: Jonathon Anderson (overrides author)
+.. itunes_summary: The latest episode! (overrides category description)
+.. itunes_image: episode-art.png (overrides POSTCAST_ITUNES_IMAGE)
+.. itunes_duration: 30:25 (MM:SS)
+.. itunes_subtitle: All the sound that's fit to cast
+.. itunes_explicit: False (overrides POSTCAST_ITUNES_EXPLICIT)

--- a/v8/postcast/post.rst.sample
+++ b/v8/postcast/post.rst.sample
@@ -1,8 +1,11 @@
-.. enclosure: episode.mp3
 .. author: Jonathon Anderson
-.. itunes_author: Jonathon Anderson (overrides author)
-.. itunes_summary: The latest episode! (overrides category description)
-.. itunes_image: episode-art.png (overrides POSTCAST_ITUNES_IMAGE)
-.. itunes_duration: 30:25 (MM:SS)
-.. itunes_subtitle: All the sound that's fit to cast
-.. itunes_explicit: False (overrides POSTCAST_ITUNES_EXPLICIT)
+.. enclosure: episode.mp3
+.. itunes_image: episode-art.png
+.. itunes_duration: 30:25
+
+.. image:: episode-art.png
+   :width: 20em
+   :alt: displaying the episode art in the HTML view of the post
+   :align: right
+
+Thanks for listening to our latest episode!

--- a/v8/postcast/postcast.plugin
+++ b/v8/postcast/postcast.plugin
@@ -1,0 +1,13 @@
+[Core]
+Name = postcast
+Module = postcast
+
+[Nikola]
+MinVersion = 8.0.0
+PluginCategory = Task
+
+[Documentation]
+Author = Jonathon Anderson
+Version = 0.2
+Website = https://plugins.getnikola.com/#postcast
+Description = Generates podcast/netcast RSS feeds from posts

--- a/v8/postcast/postcast.py
+++ b/v8/postcast/postcast.py
@@ -1,0 +1,300 @@
+# -*- coding: utf-8 -*-
+
+# Copyright © 2019 Jonathon Anderson
+# Original speechsynthesizednetcast copyright © 2013–2014 Daniel Aleksandersen and others
+
+# Permission is hereby granted, free of charge, to any
+# person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the
+# Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the
+# Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice
+# shall be included in all copies or substantial portions of
+# the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+# PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+# OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import mimetypes
+import os
+try:
+    from urlparse import urljoin
+except ImportError:
+    from urllib.parse import urljoin
+
+from nikola.plugin_categories import Task
+
+from nikola import utils
+
+
+class Postcast (Task):
+    """Generate an RSS podcast/netcast from posts."""
+
+    doc_purpose = "Generate an RSS podcast/netcast from posts."
+
+    logger = None
+
+    name = 'postcast'
+
+    def gen_tasks(self):
+        config = self.site.config
+
+        self.logger = utils.get_logger('postcast')
+
+        self.site.scan_posts()
+        yield self.group_task()
+
+        for slug in config.get('POSTCASTS', []):
+            category = _get_with_default_key(
+                config.get('POSTCAST_CATEGORY', {}), slug, '')
+            tags = _get_with_default_key(
+                config.get('POSTCAST_TAGS', {}), slug, '')
+            itunes_explicit = _get_with_default_key(
+                config.get('POSTCAST_ITUNES_EXPLICIT', {}), slug, '')
+            itunes_image = _get_with_default_key(
+                config.get('POSTCAST_ITUNES_IMAGE', {}), slug, '')
+            itunes_categories = _get_with_default_key(
+                config.get('POSTCAST_ITUNES_CATEGORIES'), slug, '')
+
+            for lang in config['TRANSLATIONS']:
+                if category:
+                    title = config['CATEGORY_TITLES'][lang].get(category)
+                    description = config['CATEGORY_DESCRIPTIONS'][lang].get(category)
+                else:
+                    title = None
+                    description = None
+
+                posts = [
+                    post for post in self.site.posts
+                    if post.is_translation_available(lang)
+                    and (post.meta('category', lang) == category if category else True)
+                    and (set(post.tags_for_language(lang)) >= set(tags) if tags else True)
+                ]
+
+                feed_deps = [self.site.configuration_filename]
+                for post in posts:
+                    feed_deps.append(post.source_path)
+                    feed_deps.append(self.audio_path(lang=lang, post=post))
+
+                output_path = self.feed_path(slug, lang)
+
+                yield {
+                    'basename': self.name,
+                    'name': str(output_path),
+                    'targets': [output_path],
+                    'file_dep': feed_deps,
+                    'clean': True,
+                    'actions': [(self.render_feed, [slug, posts, output_path], {
+                        'description': description,
+                        'itunes_categories': itunes_categories,
+                        'itunes_explicit': itunes_explicit,
+                        'itunes_image': itunes_image,
+                        'lang': lang,
+                        'title': title,
+                    })]
+                }
+
+    def render_feed(self, slug, posts, output_path, lang=None, title=None, description=None, itunes_explicit=None, itunes_categories=None, itunes_image=None):
+        config = self.site.config
+        rss_obj = self.site.generic_rss_feed(
+            lang=lang,
+            title=title,
+            link=config['SITE_URL'],
+            description=description,
+            timeline=posts,
+            rss_teasers=True,
+            rss_plain=True,
+            feed_length=config['FEED_LENGTH'],
+            feed_url=self.feed_url(slug, lang),
+            enclosure=self.enclosure,
+        )
+        rss_obj = self.with_itunes_tags(
+            rss_obj, lang, posts,
+            explicit=itunes_explicit,
+            image=itunes_image,
+            categories=itunes_categories,
+        )
+        utils.rss_writer(rss_obj, output_path)
+        return output_path
+
+    def with_itunes_tags(self, rss_obj, lang, posts, explicit=None, image=None, categories=None):
+        config = self.site.config
+        rss_obj = ITunesRSS2.from_rss2(rss_obj)
+        rss_obj.rss_attrs["xmlns:itunes"] = "http://www.itunes.com/dtds/podcast-1.0.dtd"
+        rss_obj.itunes_author = config['BLOG_AUTHOR'](lang)
+        rss_obj.itunes_name = config['BLOG_AUTHOR'](lang)
+        rss_obj.itunes_email = config['BLOG_EMAIL']
+        rss_obj.itunes_summary = rss_obj.description
+        rss_obj.itunes_explicit = explicit
+        if image:
+            rss_obj.itunes_image = urljoin(config['BASE_URL'], image)
+        rss_obj.itunes_categories = categories
+
+        itunes_items = []
+        for post, item in zip(posts, rss_obj.items):
+            itunes_item = ITunesItem.from_rss_item(item)
+            for suffix in ('subtitle', 'duration', 'explicit'):
+                tag = 'itunes_{}'.format(suffix)
+                setattr(itunes_item, tag, post.meta(tag, lang))
+            itunes_item.itunes_author = post.meta('itunes_author', lang) or post.author(lang)
+            itunes_item.itunes_summary = post.meta('itunes_summary', lang) or itunes_item.description
+            if post.meta('itunes_image', lang):
+                itunes_item.itunes_image = self.site.url_replacer(
+                    post.permalink(), post.meta('itunes_image', lang), lang, 'absolute')
+            itunes_items.append(itunes_item)
+        rss_obj.items = itunes_items
+
+        return rss_obj
+
+    def feed_url(self, slug, lang=None):
+        config = self.site.config
+        return urljoin(config['BASE_URL'], self.feed_path(slug, lang=lang, is_link=True))
+
+    def feed_path(self, slug, lang=None, is_link=False):
+        config = self.site.config
+        path = []
+        if not is_link:
+            path.append(config['OUTPUT_FOLDER'])
+        path.append(config.get('POSTCAST_PATH', 'casts'))
+        path.extend([config['TRANSLATIONS'][lang], '{}.xml'.format(slug)])
+        return os.path.normpath(os.path.join(*path))
+
+    def enclosure (self, post=None, lang=None):
+        download_url = self.audio_url(lang=lang, post=post)
+        audio_path = self.audio_path(lang=lang, post=post)
+        download_size = os.stat(audio_path).st_size
+        download_type, _ = mimetypes.guess_type(download_url)
+        return download_url, download_size, download_type
+
+    def audio_url(self, lang=None, post=None):
+        config = self.site.config
+        return urljoin(config['BASE_URL'], self.audio_path(lang=lang, post=post, is_link=True))
+
+    def audio_path(self, lang=None, post=None, is_link=False):
+        config = self.site.config
+        path = []
+        if not is_link:
+            path.append(config['OUTPUT_FOLDER'])
+        path.append(os.path.dirname(post.destination_path(lang=lang)))
+        path.append(post.meta('enclosure', lang))
+        return os.path.normpath(os.path.join(*path))
+
+
+class ITunesRSS2(utils.ExtendedRSS2):
+    """Extended RSS class."""
+
+    xsl_stylesheet_href = None
+
+    def __init__(self, itunes_author=None, itunes_summary=None,
+                 itunes_name=None, itunes_email=None,
+                 itunes_image=None, itunes_categories=None,
+                 itunes_explicit=None, **kwargs):
+        utils.ExtendedRSS2.__init__(self, **kwargs)
+        self.itunes_author = itunes_author
+        self.itunes_summary = itunes_summary
+        self.itunes_name = itunes_name
+        self.itunes_email = itunes_email
+        self.itunes_image = itunes_image
+        self.itunes_categories = itunes_categories
+        self.itunes_explicit = itunes_explicit
+
+    @classmethod
+    def from_rss2(cls, rss2):
+        new_rss2 = cls(title=rss2.title, link=rss2.link,
+                       description=rss2.description)
+        new_rss2.__dict__.update(rss2.__dict__)
+        return new_rss2
+
+    def publish_extensions(self, handler):
+        utils.ExtendedRSS2.publish_extensions(self, handler)
+
+        for tag in ('author', 'summary'):
+            _simple_itunes_tag(self, handler, tag)
+        _itunes_image_tag(self, handler)
+        _itunes_explicit_tag(self, handler)
+
+        if self.itunes_name or self.itunes_email:
+            handler.startElement("itunes:owner", {})
+            _simple_itunes_tag(self, handler, 'name')
+            _simple_itunes_tag(self, handler, 'email')
+            handler.endElement("itunes:owner")
+
+        if self.itunes_categories:
+            for category_entry in self.itunes_categories:
+                try:
+                    category, subcategories = category_entry
+                except ValueError:
+                    category = category_entry[0]
+                    subcategories = ()
+                handler.startElement("itunes:category", {'text': category})
+                for subcategory in subcategories:
+                    handler.startElement("itunes:category", {'text': subcategory})
+                    handler.endElement("itunes:category")
+                handler.endElement("itunes:category")
+
+    def _itunes_attributes(self):
+        for tag in ('author', 'summary', 'name', 'email', 'image', 'categories', 'explicit'):
+            yield 'itunes:{}'.format(tag), getattr(self, 'itunes_{}'.format(tag))
+
+
+class ITunesItem(utils.ExtendedItem):
+
+    def __init__(self, itunes_author=None, itunes_subtitle=None,
+                 itunes_summary=None, itunes_image=None,
+                 itunes_duration=None, itunes_explicit=None, **kwargs):
+        utils.ExtendedItem.__init__(self, **kwargs)
+        self.itunes_author = itunes_author
+        self.itunes_subtitle = itunes_subtitle
+        self.itunes_summary = itunes_summary
+        self.itunes_image = itunes_image
+        self.itunes_duration = itunes_duration
+        self.itunes_explicit = itunes_explicit
+
+    @classmethod
+    def from_rss_item(cls, item):
+        new_item = cls(title=item.title, link=item.link, description=item.description)
+        new_item.__dict__.update(item.__dict__)
+        return new_item
+
+    def publish_extensions(self, handler):
+        utils.ExtendedItem.publish_extensions(self, handler)
+        for tag in ('author', 'subtitle', 'summary', 'duration'):
+            _simple_itunes_tag(self, handler, tag)
+        _itunes_image_tag(self, handler)
+        _itunes_explicit_tag(self, handler)
+
+
+def _simple_itunes_tag(src, handler, tag):
+    itunes_tag = "itunes:{}".format(tag)
+    value = getattr(src, 'itunes_{}'.format(tag))
+    if value:
+        handler.startElement(itunes_tag, {})
+        handler.characters(value)
+        handler.endElement(itunes_tag)
+
+
+def _itunes_explicit_tag(src, handler):
+    if src.itunes_explicit is not None:
+        handler.startElement("itunes:explicit", {})
+        handler.characters("yes" if src.itunes_explicit else "no")
+        handler.endElement("itunes:explicit")
+
+
+def _itunes_image_tag(src, handler):
+    if src.itunes_image:
+        handler.startElement("itunes:image", {'href': src.itunes_image})
+        handler.endElement("itunes:image")
+
+
+def _get_with_default_key(config, key, default_key):
+    return config.get(key, config.get(default_key))

--- a/v8/postcast/postcast.py
+++ b/v8/postcast/postcast.py
@@ -76,9 +76,9 @@ class Postcast (Task):
 
                 posts = [
                     post for post in self.site.posts
-                    if post.is_translation_available(lang)
-                    and (post.meta('category', lang) == category if category else True)
-                    and (set(post.tags_for_language(lang)) >= set(tags) if tags else True)
+                    if post.is_translation_available(lang) and
+                    (post.meta('category', lang) == category if category else True) and
+                    (set(post.tags_for_language(lang)) >= set(tags) if tags else True)
                 ]
 
                 feed_deps = [self.site.configuration_filename]
@@ -169,7 +169,7 @@ class Postcast (Task):
         path.extend([config['TRANSLATIONS'][lang], '{}.xml'.format(slug)])
         return os.path.normpath(os.path.join(*path))
 
-    def enclosure (self, post=None, lang=None):
+    def enclosure(self, post=None, lang=None):
         download_url = self.audio_url(lang=lang, post=post)
         audio_path = self.audio_path(lang=lang, post=post)
         download_size = os.stat(audio_path).st_size


### PR DESCRIPTION
The postcast plugin generates podcast/netcast rss feeds from posts. It supports using categories and tags to indicate which tags contain podcast episodes, including different filters for different simultaneous feeds.

I've recently ported this plugin from v7 as part of a revamp of my personal site, https://civilfritz.net/. An example of a feed generated with this plugin can be found at https://civilfritz.net/casts/gameolder.xml.