### PR TITLE
Add org-mode support for internal links (incl. update documentation)

### DIFF
--- a/v8/orgmode/README.md
+++ b/v8/orgmode/README.md
@@ -44,3 +44,7 @@ because the path is considered as an absolute file path.
 
 In order to correctly generate image urls, you may write `[[img-url:/images/test.jpg]]`,
 and then it should be generated as `<img src="/images/test.jpg" alt="test.jpg">`.
+
+The internal link in ox-html is a little fuzzy. For example, `[[./test.org][test]]` will be generated as `<a href="file:///./test.jpg">"test"` because the path is considered as an absolute file path.
+
+In order to correctly generate internal link urls, you may write `[[int-url:./test][test]` (i.e. JUST THE FILENAME WITHOUT THE .org EXTENSION PART), and then it should be generated as <a href="./test/index.html">"test".

--- a/v8/orgmode/init.el
+++ b/v8/orgmode/init.el
@@ -111,6 +111,13 @@ contextual information."
             (pygmentize (downcase lang) (org-html-decode-plain-text code)))
         code-html))))
 
+;; Export internal links with custom link type
+(defun org-custom-internal-link-url-export (path desc format)
+  (cond
+   ((eq format 'html)
+    (format "<a href=\"%s/index.html\">\"%s\"" path desc))))
+(org-add-link-type "int-url" nil 'org-custom-internal-link-url-export)
+
 ;; Export images with custom link type
 (defun org-custom-link-img-url-export (path desc format)
   (cond


### PR DESCRIPTION
Similar to the problem with image url's, the url's of internal link are also not handled well by ox-html for correct use with nikola. I copied and slightly the solution for handling image urls so that internal urls will also be handled correctly now with org-mode.

In addition to changing the implementing the code I updated the documentation in the README file for the plugin.

