### PR TITLE
Fix gallery path for windows python

### DIFF
--- a/v7/gallery_directive/gallery_directive.py
+++ b/v7/gallery_directive/gallery_directive.py
@@ -78,6 +78,8 @@ class Gallery(Directive):
         for img in photo_array:
             img['url'] = '/' + '/'.join([gallery_folder, img['url']])
             img['url_thumb'] = '/' + '/'.join([gallery_folder, img['url_thumb']])
+            img['url'] = img['url'].replace("\\","/")
+            img['url_thumb'] = img['url_thumb'].replace("\\","/")
         photo_array_json = json.dumps(photo_array)
         context = {}
         context['description'] = ''


### PR DESCRIPTION
On Windows 10 anaconda python, this plugin uses "\"  or "%5C" instead of "/" between site/galleries and gallery name. Kludge fix.