### PR TITLE
plugin: devto, push new articles directly to your dev.to account

### DIFF
--- a/v8/devto/README.md
+++ b/v8/devto/README.md
@@ -1,0 +1,26 @@
+What is this?
+-------------
+
+This plugin can publish your Nikola content to your Devto site.
+
+
+How to Use it
+-------------
+
+1. Setup a Devto account.
+2. Install the plugin using ``nikola plugin -i devto``
+3. Get your API token from  your [Devto Settings Page](https://docs.dev.to/api/)
+4. Save the Client ID and Client Secret in ``devto.json`` like this:
+
+```
+{
+  "TOKEN": "<your_devto_token>",
+}
+```
+
+4. Run ``nikola devto``
+
+At that point your posts with the "devto" metadata set to "yes" or "true" should be published.
+This plugin is testing if your article was already published so don't worry for double posting.
+
+Enjoy!

--- a/v8/devto/devto.plugin
+++ b/v8/devto/devto.plugin
@@ -1,0 +1,12 @@
+[Core]
+Name = devto
+Module = devto_plugin
+
+[Nikola]
+PluginCategory = Command
+
+[Documentation]
+Author = Mathieu Dugue
+Version = 0.1
+Website = http://plugins.getnikola.com/#devto
+Description = Publish posts to Devto

--- a/v8/devto/devto_plugin.py
+++ b/v8/devto/devto_plugin.py
@@ -25,8 +25,6 @@
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-from __future__ import print_function, unicode_literals
-
 import json
 import os
 

--- a/v8/devto/devto_plugin.py
+++ b/v8/devto/devto_plugin.py
@@ -64,12 +64,12 @@ class CommandDevto(Command):
         self.site.scan_posts()
 
         posts = self.site.timeline
-        toPost = [post for post in posts if not next((item for item in articles if item["title"] == post.title()), False) and post.meta('devto')]
+        to_post = [post for post in posts if not next((item for item in articles if item["title"] == post.title()), False) and post.meta('devto')]
 
-        if len(toPost) == 0:
+        if len(to_post) == 0:
             print("Nothing new to post...")
 
-        for post in toPost:
+        for post in to_post:
             if post.source_ext() == '.md':
                 with open(post.source_path, 'r') as file:
                     data = file.readlines()
@@ -80,15 +80,13 @@ class CommandDevto(Command):
                         canonical_url=post.permalink(absolute=True),
                         tags=post.tags
                     )
-                    print('Published %s to %s' %
-                    (post.meta('slug'), m_post['url']))
+                    print('Published {} to {}', post.meta('slug'), m_post['url'])
             elif post.source_ext() == '.rst':
                 m_post = api.create_article(
                     title=post.title(),
-                    body_markdown = pypandoc.convert_file(post.source_path, to='gfm', format='rst'),
+                    body_markdown=pypandoc.convert_file(post.source_path, to='gfm', format='rst'),
                     published=True,
                     canonical_url=post.permalink(absolute=True),
                     tags=post.tags
                 )
-                print('Published %s to %s' %
-                (post.meta('slug'), m_post['url']))
+                print('Published {} to {}', post.meta('slug'), m_post['url'])

--- a/v8/devto/devto_plugin.py
+++ b/v8/devto/devto_plugin.py
@@ -80,7 +80,7 @@ class CommandDevto(Command):
                         canonical_url=post.permalink(absolute=True),
                         tags=post.tags
                     )
-                    print('Published {} to {}', post.meta('slug'), m_post['url'])
+                    print('Published {} to {}'.format(post.meta('slug'), m_post['url']))
             elif post.source_ext() == '.rst':
                 m_post = api.create_article(
                     title=post.title(),
@@ -89,4 +89,4 @@ class CommandDevto(Command):
                     canonical_url=post.permalink(absolute=True),
                     tags=post.tags
                 )
-                print('Published {} to {}', post.meta('slug'), m_post['url'])
+                print('Published {} to {}'.format(post.meta('slug'), m_post['url']))

--- a/v8/devto/devto_plugin.py
+++ b/v8/devto/devto_plugin.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+
+# Copyright © 2020 Roberto Alsina and others.
+
+# Permission is hereby granted, free of charge, to any
+# person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the
+# Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the
+# Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice
+# shall be included in all copies or substantial portions of
+# the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+# PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+# OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+from __future__ import print_function, unicode_literals
+
+import json
+import os
+
+import pypandoc
+import pydevto
+
+from nikola import utils
+from nikola.plugin_categories import Command
+
+LOGGER = utils.get_logger('Devto')
+
+
+class CommandDevto(Command):
+    """
+    This class is based on the package medium (https://plugins.getnikola.com/v8/medium/)
+    """
+
+    name = "devto"
+    needs_config = True
+    doc_usage = ""
+    doc_purpose = "Publish your articles to Dev.to"
+
+    def _execute(self, options, args):
+        """Publish to Dev.to."""
+
+        if not os.path.exists('devto.json'):
+            LOGGER.error(
+                'Please put your credentials in devto.json as described in the README.')
+            return False
+        with open('devto.json') as inf:
+            creds = json.load(inf)
+        api = pydevto.PyDevTo(api_key=creds['TOKEN'])
+
+        articles = api.articles()
+        self.site.scan_posts()
+
+        posts = self.site.timeline
+        toPost = [post for post in posts if not next((item for item in articles if item["title"] == post.title()), False) and post.meta('devto')]
+
+        if len(toPost) == 0:
+            print("Nothing new to post...")
+
+        for post in toPost:
+            if post.source_ext() == '.md':
+                with open(post.source_path, 'r') as file:
+                    data = file.readlines()
+                    m_post = api.create_article(
+                        title=post.title(),
+                        body_markdown="".join(data),
+                        published=True,
+                        canonical_url=post.permalink(absolute=True),
+                        tags=post.tags
+                    )
+                    print('Published %s to %s' %
+                    (post.meta('slug'), m_post['url']))
+            elif post.source_ext() == '.rst':
+                m_post = api.create_article(
+                    title=post.title(),
+                    body_markdown = pypandoc.convert_file(post.source_path, to='gfm', format='rst'),
+                    published=True,
+                    canonical_url=post.permalink(absolute=True),
+                    tags=post.tags
+                )
+                print('Published %s to %s' %
+                (post.meta('slug'), m_post['url']))

--- a/v8/devto/requirements.txt
+++ b/v8/devto/requirements.txt
@@ -1,0 +1,2 @@
+pydevto
+pypandoc


### PR DESCRIPTION
Following how the `medium`plugin was done I implemented a new plugin that can post any blog posts (written in `.md` or `.rst`) to your https://dev.to profile.

You just need to get the token as explained in the README.me file.

The plugin also check if the posts were already published to avoid republishing something that was already published.