### PR TITLE
feat: removing the table of content and adding the title if not present before posting to medium

### DIFF
--- a/v8/medium/README.md
+++ b/v8/medium/README.md
@@ -20,4 +20,6 @@ How to Use it
 
 4. Run ``nikola medium``
 
-At that point your posts with the "medium" metadata set to "yes" should be published. Have fun!
+At that point your posts with the "medium" metadata set to "yes" should be published.
+
+**Be aware that if you use the command again after a short period of time it might post duplicate article, medium is taking a bit of time before updating the list of your posted articles that I compare from to avoid that.**

--- a/v8/medium/README.md
+++ b/v8/medium/README.md
@@ -1,10 +1,11 @@
-What is this?
+# What is this
+
 -------------
 
 This plugin lets syndicate Nikola content to your Medium site.
 
+## How to Use it
 
-How to Use it
 -------------
 
 1. Setup a Medium account.
@@ -12,13 +13,13 @@ How to Use it
 3. Get an integration token from  your [Medium Settings Page](https://medium.com/me/settings)
 4. Save the Client ID and Client Secret in ``medium.json`` like this:
 
-```
+``` json
 {
   "TOKEN": "asdasdasdasd",
 }
 ```
 
-4. Run ``nikola medium``
+5. Run ``nikola medium``
 
 At that point your posts with the "medium" metadata set to "yes" should be published.
 

--- a/v8/medium/medium.plugin
+++ b/v8/medium/medium.plugin
@@ -7,6 +7,6 @@ PluginCategory = Command
 
 [Documentation]
 Author = Roberto Alsina
-Version = 0.2
+Version = 0.3
 Website = http://plugins.getnikola.com/#medium
 Description = Publish posts to Medium

--- a/v8/medium/medium_plugin.py
+++ b/v8/medium/medium_plugin.py
@@ -33,7 +33,9 @@ from medium import Client
 from nikola import utils
 from nikola.plugin_categories import Command
 
-LOGGER = utils.get_logger('Medium')
+from bs4 import BeautifulSoup
+
+LOGGER = utils.get_logger("Medium")
 
 
 class CommandMedium(Command):
@@ -46,34 +48,49 @@ class CommandMedium(Command):
 
     def _execute(self, options, args):
         """Publish to Medium."""
-        if not os.path.exists('medium.json'):
+        if not os.path.exists("medium.json"):
             LOGGER.error(
-                'Please put your credentials in medium.json as described in the README.')
+                "Please put your credentials in medium.json as described in the README."
+            )
             return False
-        with open('medium.json') as inf:
+        with open("medium.json") as inf:
             creds = json.load(inf)
         client = Client()
-        client.access_token = creds['TOKEN']
+        client.access_token = creds["TOKEN"]
         user = client.get_current_user()
 
         self.site.scan_posts()
-        feed = client.list_articles(user['username'])
+        feed = client.list_articles(user["username"])
         posts = self.site.timeline
 
-        toPost = [post for post in posts if not next((item for item in feed if item["title"] == post.title()), False) and post.meta('medium')]
+        medium_titles = {item["title"] for item in feed}
+        to_post = [
+            post
+            for post in posts
+            if post.title() not in medium_titles and post.meta("medium")
+        ]
 
-        if len(toPost) == 0:
+        if len(to_post) == 0:
             print("Nothing new to post...")
 
-        for post in toPost:
+        for post in to_post:
+            parse_post = BeautifulSoup(post.text(), "html.parser")
+            nav = parse_post.find("nav", id="TOC")
+            if nav:
+                nav.extract()
+            if not parse_post.find("h1"):
+                tag = parse_post.new_tag("h1")
+                tag.string = post.title()
+                body = parse_post.find("body")
+                body.insert(0, tag)
+
             m_post = client.create_post(
                 user_id=user["id"],
                 title=post.title(),
-                content=post.text(),
+                content=str(parse_post),
                 content_format="html",
                 publish_status="public",
                 canonical_url=post.permalink(absolute=True),
-                tags=post.tags
+                tags=post.tags,
             )
-            print('Published %s to %s' %
-                  (post.meta('slug'), m_post['url']))
+            print("Published %s to %s" % (post.meta("slug"), m_post["url"]))

--- a/v8/medium/medium_plugin.py
+++ b/v8/medium/medium_plugin.py
@@ -34,8 +34,6 @@ from nikola import utils
 from nikola.plugin_categories import Command
 from lxml import html, etree
 
-from bs4 import BeautifulSoup
-
 LOGGER = utils.get_logger("Medium")
 
 


### PR DESCRIPTION
I improved the medium plugin by using BeautifulSoup to remove the generated table of content because it's totally messing the medium article.

I also added a `<h1>` tag with the post title in the article if it's not present already because filling the title attribute in the medium api doesnt work and the article ends up being without any title.

I also formatted the previous code to be compliant with PEP style.