### PR TITLE
[asciidoc] Repair user-provided ASCIIDOC_OPTIONS

### DIFF
--- a/v8/asciidoc/asciidoc.py
+++ b/v8/asciidoc/asciidoc.py
@@ -55,12 +55,13 @@ class CompileAsciiDoc(PageCompiler):
         binary = self.site.config.get('ASCIIDOC_BINARY', 'asciidoc')
         options = self.site.config.get('ASCIIDOC_OPTIONS', '')
         options = shlex.split(options)
+        command = [binary, '-b', 'html5', '-s'] + options + ['-']
         if not is_two_file:
             m_data, data = self.split_metadata(data, post, lang)
 
         from nikola import shortcodes as sc
         new_data, shortcodes = sc.extract_shortcodes(data)
-        p = subprocess.Popen([binary, '-b', 'html5', '-s', '-'] + options, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+        p = subprocess.Popen(command, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
         output = p.communicate(input=new_data.encode('utf8'))[0].decode('utf8')
         output, shortcode_deps = self.site.apply_shortcodes_uuid(output, shortcodes, filename=source_path, extra_context={'post': post})
         return output, p.returncode, [], shortcode_deps


### PR DESCRIPTION
The ASCIIDOC_OPTIONS value from conf.py was being inserted at the end of
the asciidoc command line, after the input file ('-'). This causes
asciidoc to fail with:

    asciidoc: Too many arguments

The solution is to insert ASCIIDOC_OPTIONS before the input file
argument.

Signed-off-by: Peter Grayson <pete@jpgrayson.net>