### PR TITLE
Warn about new_page in hierarchical pages readme

### DIFF
--- a/v8/hierarchical_pages/README.md
+++ b/v8/hierarchical_pages/README.md
@@ -48,3 +48,5 @@ If you use plain Nikola instead, the URLs would be:
 * `https://example.com/de/about/team/roberto-alsina/`
 
 Note that this plugin requires Nikola 8 or newer.
+Additionally, since the `PAGES` variable in your `conf.py` is now empty, the command `nikola new_page` will no longer work.
+You can instead create new pages by manually entering the correct metadata.


### PR DESCRIPTION
Resolves #350 . The hierarchical pages plugin makes it no longer possible to use the `nikola new_page` command. Instead, new pages with the right metadata have to be created manually, but this fact wasn't documented before.