### PR TITLE
postcast: allow setting a different base url for enclosure files

### DIFF
--- a/v8/postcast/conf.py.sample
+++ b/v8/postcast/conf.py.sample
@@ -2,6 +2,16 @@
 
 # example settings for postcast nikola plugin
 
+# If you're using a CDN for storage, you can set a base URL different
+# from your blog's URL.
+# POSTCAST_BASE_URL = "https://cdn.example.org/files/"
+
+# If you're using a CDN you may want to keep your local podcast files
+# separate from the OUTPUT_FOLDER.
+# When POSTCAST_ENCLOSURE_FOLDER is set, all enclosure files will be
+# searched for there, instead of the post output directory.
+# POSTCAST_ENCLOSURE_FOLDER = "podcasts"
+
 # Path for where postcast feeds will be generated.
 
 # Final locations are:

--- a/v8/postcast/postcast.py
+++ b/v8/postcast/postcast.py
@@ -178,7 +178,7 @@ class Postcast (Task):
 
     def audio_url(self, lang=None, post=None):
         config = self.site.config
-        baseurl = config.get('POSTCAST_BASE_URL') or config['BASE_URL']
+        baseurl = config.get('POSTCAST_BASE_URL', config['BASE_URL'])
         return urljoin(baseurl, self.audio_path(lang=lang, post=post, is_link=True))
 
     def audio_path(self, lang=None, post=None, is_link=False):

--- a/v8/postcast/postcast.py
+++ b/v8/postcast/postcast.py
@@ -178,14 +178,20 @@ class Postcast (Task):
 
     def audio_url(self, lang=None, post=None):
         config = self.site.config
-        return urljoin(config['BASE_URL'], self.audio_path(lang=lang, post=post, is_link=True))
+        baseurl = config.get('POSTCAST_BASE_URL') or config['BASE_URL']
+        return urljoin(baseurl, self.audio_path(lang=lang, post=post, is_link=True))
 
     def audio_path(self, lang=None, post=None, is_link=False):
         config = self.site.config
+        enclosure_path = config.get('POSTCAST_ENCLOSURE_FOLDER')
         path = []
         if not is_link:
-            path.append(config['OUTPUT_FOLDER'])
-        path.append(os.path.dirname(post.destination_path(lang=lang)))
+            if enclosure_path:
+                path.append(enclosure_path)
+            else:
+                path.append(config['OUTPUT_FOLDER'])
+        if not enclosure_path:
+            path.append(os.path.dirname(post.destination_path(lang=lang)))
         path.append(post.meta('enclosure', lang))
         return os.path.normpath(os.path.join(*path))
 


### PR DESCRIPTION
adds two new config vars `POSTCAST_BASE_URL` and `POSTCAST_ENCLOSURE_FOLDER` which allow to use a base URL completely different from your blog's URL, and to keep the podcast files locally in a separate location, so they don't have to be part of the build process and can be synced separately.

fixes #352