### PR TITLE
orgmode: Support magic links (fix #354)

### DIFF
--- a/v8/orgmode/init.el
+++ b/v8/orgmode/init.el
@@ -125,6 +125,15 @@ contextual information."
     (format "<img src=\"/%s\" alt=\"%s\"/>" path desc))))
 (org-add-link-type "file" nil 'org-file-link-img-url-export)
 
+;; Support for magic links (link:// scheme)
+(org-link-set-parameters
+  "link"
+  :export (lambda (path desc backend)
+             (cond
+               ((eq 'html backend)
+                (format "<a href=\"link:%s\">%s</a>"
+                        path (or desc path))))))
+
 ;; Export function used by Nikola.
 (defun nikola-html-export (infile outfile)
   "Export the body only of the input file and write it to


### PR DESCRIPTION
This fixes #354 and adds support for magic links (`link://` scheme) to orgmode.

cc @ndvanforeest, @punchagan
