### PR TITLE
Convert test_command_tags.py & test_helloworld.py to use pytest

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+__all__ = [
+    'V7_PLUGIN_PATH',
+]
+
+V7_PLUGIN_PATH = Path(__file__).parent.parent / 'v7'

--- a/tests/test_command_tags.py
+++ b/tests/test_command_tags.py
@@ -1,18 +1,16 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import logging
 import os
 import re
 import shutil
 import sys
-import tempfile
-import unittest
+
+import pytest
+from pytest import fixture
 
 from nikola import nikola
-
-PLUGIN_PATH = os.path.abspath(os.path.join('v7', 'tags'))
-sys.path.append(PLUGIN_PATH)
+from tests import V7_PLUGIN_PATH
 
 try:
     from freezegun import freeze_time
@@ -21,48 +19,35 @@ except ImportError:
     _freeze_time = False
     freeze_time = lambda x: lambda y: y
 
-from tags import (
+from v7.tags.tags import (
     _AutoTag, add_tags, list_tags, merge_tags, remove_tags, search_tags,
     sort_tags
 )
-from nikola.utils import _reload, LOGGER
+from nikola.utils import _reload
+
 DEMO_TAGS = ['python', 'demo', 'nikola', 'blog']
 
 
-def setUpModule():
-    LOGGER.notice('--- TESTS FOR tags')
-    LOGGER.level = logging.WARNING
-
-
-def tearDownModule():
-    sys.stdout.write('\n')
-    LOGGER.level = logging.INFO
-    LOGGER.notice('--- END OF TESTS FOR tags')
-
-
-class TestCommandTagsBase(unittest.TestCase):
+class TestCommandTagsBase:
 
     def _add_test_post(self, title, tags):
         self._run_command(['new_post', '-t', title, '--tags', ','.join(tags)])
-
-    def _create_temp_dir_and_cd(self):
-        self._testdir = tempfile.mkdtemp()
-        self._old_dir = os.getcwd()
-        os.chdir(self._testdir)
 
     def _force_scan(self):
         self._site._scanned = False
         self._site.scan_posts(True)
 
-    def _init_site(self):
+    @fixture(autouse=True)
+    def _init_site(self, monkeypatch, tmp_path):
         from nikola.plugins.command.init import CommandInit
 
+        monkeypatch.chdir(tmp_path)
         command_init = CommandInit()
         command_init.execute(options={'demo': True, 'quiet': True}, args=['demo'])
 
         sys.path.insert(0, '')
-        os.chdir('demo')
-        import conf
+        monkeypatch.chdir(tmp_path / 'demo')
+        import conf  # noqa
         _reload(conf)
         sys.path.pop(0)
 
@@ -77,10 +62,6 @@ class TestCommandTagsBase(unittest.TestCase):
             if post.source_path == source
         ]
         return posts[0].tags
-
-    def _remove_temp_dir(self):
-        os.chdir(self._old_dir)
-        shutil.rmtree(self._testdir)
 
     def _run_command(self, args=[]):
         from nikola.__main__ import main
@@ -97,17 +78,9 @@ class TestCommandTagsHelpers(TestCommandTagsBase):
 
     """
 
+    @fixture(autouse=True)
     def setUp(self):
-        """ Create a demo site, for testing. """
-
-        self._create_temp_dir_and_cd()
-        self._init_site()
-        # Scan for posts, since the helpers don't do it.
-        self._scan_posts()
-
-    def tearDown(self):
-        """ Restore world order. """
-        self._remove_temp_dir()
+        self._site.scan_posts()
 
     # ### `TestCommandTagsHelpers` protocol ###################################
 
@@ -118,8 +91,8 @@ class TestCommandTagsHelpers(TestCommandTagsBase):
         new_tags = add_tags(self._site, tags, posts)
         new_parsed_tags = self._parse_new_tags(posts[0])
 
-        self.assertTrue('test_nikola' in new_tags[0])
-        self.assertEqual(set(new_tags[0]), set(new_parsed_tags))
+        assert 'test_nikola' in new_tags[0]
+        assert set(new_tags[0]) == set(new_parsed_tags)
 
     def test_add_dry_run(self):
         posts = [os.path.join('posts', post) for post in os.listdir('posts')]
@@ -128,8 +101,8 @@ class TestCommandTagsHelpers(TestCommandTagsBase):
         new_tags = add_tags(self._site, tags, posts, dry_run=True)
         new_parsed_tags = self._parse_new_tags(posts[0])
 
-        self.assertTrue('test_nikola' in new_tags[0])
-        self.assertEqual(set(new_parsed_tags), set(DEMO_TAGS))
+        assert 'test_nikola' in new_tags[0]
+        assert set(new_parsed_tags) == set(DEMO_TAGS)
 
     def test_auto_tag_basic(self):
         post = os.path.join('posts', os.listdir('posts')[0])
@@ -143,7 +116,7 @@ class TestCommandTagsHelpers(TestCommandTagsBase):
         # simple tagging test.
         tags = tagger.tag(post)
         tags = [tag for tag in tags if tag_pattern.search(tag)]
-        self.assertEqual(len(tags), 5)
+        assert len(tags) == 5
 
     def test_auto_tag_nltk(self):
         post = os.path.join('posts', os.listdir('posts')[0])
@@ -157,35 +130,35 @@ class TestCommandTagsHelpers(TestCommandTagsBase):
         # tagging with nltk.
         nltk_tags = tagger.tag(post)
         tags = [tag for tag in nltk_tags if tag_pattern.search(tag)]
-        self.assertEqual(len(tags), 5)
+        assert len(tags) == 5
 
     def test_list(self):
-        self.assertEqual(sorted(DEMO_TAGS), list_tags(self._site))
+        assert list_tags(self._site) == sorted(DEMO_TAGS)
 
     def test_list_count_sorted(self):
         self._add_test_post(title='2', tags=['python'])
         self._force_scan()
         tags = list_tags(self._site, 'count')
-        self.assertEqual('python', tags[0])
+        assert tags[0] == 'python'
 
     def test_list_draft(self):
         self._add_test_post(title='2', tags=['python', 'draft'])
         self._force_scan()
         tags = list_tags(self._site)
-        self.assertIn('draft', tags)
+        assert 'draft' in tags
 
     def test_list_draft_post_tags(self):
         self._add_test_post(title='2', tags=['ruby', 'draft'])
         self._force_scan()
         tags = list_tags(self._site)
-        self.assertIn('ruby', tags)
+        assert 'ruby' in tags
 
-    @unittest.skipIf(not _freeze_time, 'freezegun package not installed.')
+    @pytest.mark.skipif(not _freeze_time, reason='freezegun package not installed.')
     def test_list_scheduled_post_tags(self):
         with freeze_time("2012-01-14"):
             self._force_scan()
             tags = list_tags(self._site)
-            self.assertIn('python', tags)
+            assert 'python' in tags
 
     def test_merge(self):
         posts = [os.path.join('posts', post) for post in os.listdir('posts')]
@@ -194,8 +167,8 @@ class TestCommandTagsHelpers(TestCommandTagsBase):
         new_tags = merge_tags(self._site, tags, posts)
         new_parsed_tags = self._parse_new_tags(posts[0])
 
-        self.assertFalse('nikola' in new_tags)
-        self.assertEqual(set(new_tags[0]), set(new_parsed_tags))
+        assert 'nikola' not in new_tags
+        assert set(new_tags[0]) == set(new_parsed_tags)
 
     def test_merge_dry_run(self):
         posts = [os.path.join('posts', post) for post in os.listdir('posts')]
@@ -204,8 +177,8 @@ class TestCommandTagsHelpers(TestCommandTagsBase):
         new_tags = merge_tags(self._site, tags, posts, dry_run=True)
         new_parsed_tags = self._parse_new_tags(posts[0])
 
-        self.assertFalse('nikola' in new_tags[0])
-        self.assertEqual(set(DEMO_TAGS), set(new_parsed_tags))
+        assert 'nikola' not in new_tags[0]
+        assert set(new_parsed_tags) == set(DEMO_TAGS)
 
     def test_remove(self):
         posts = [os.path.join('posts', post) for post in os.listdir('posts')]
@@ -214,8 +187,8 @@ class TestCommandTagsHelpers(TestCommandTagsBase):
         new_tags = remove_tags(self._site, tags, posts)
         new_parsed_tags = self._parse_new_tags(posts[0])
 
-        self.assertFalse('nikola' in new_tags)
-        self.assertEqual(set(new_tags[0]), set(new_parsed_tags))
+        assert 'nikola' not in new_tags
+        assert set(new_tags[0]) == set(new_parsed_tags)
 
     def test_remove_draft(self):
         self._add_test_post(title='2', tags=['draft'])
@@ -226,7 +199,7 @@ class TestCommandTagsHelpers(TestCommandTagsBase):
         self._force_scan()
 
         tags = list_tags(self._site, 'count')
-        self.assertNotIn('draft', tags)
+        assert 'draft' not in tags
 
     def test_remove_invalid(self):
         posts = [os.path.join('posts', post) for post in os.listdir('posts')]
@@ -235,7 +208,7 @@ class TestCommandTagsHelpers(TestCommandTagsBase):
         new_tags = remove_tags(self._site, tags, posts)
         new_parsed_tags = self._parse_new_tags(posts[0])
 
-        self.assertEqual(set(new_tags[0]), set(new_parsed_tags))
+        assert set(new_tags[0]) == set(new_parsed_tags)
 
     def test_remove_dry_run(self):
         posts = [os.path.join('posts', post) for post in os.listdir('posts')]
@@ -244,8 +217,8 @@ class TestCommandTagsHelpers(TestCommandTagsBase):
         new_tags = remove_tags(self._site, tags, posts, dry_run=True)
         new_parsed_tags = self._parse_new_tags(posts[0])
 
-        self.assertFalse('nikola' in new_tags[0])
-        self.assertEqual(set(new_parsed_tags), set(DEMO_TAGS))
+        assert 'nikola' not in new_tags[0]
+        assert set(new_parsed_tags) == set(DEMO_TAGS)
 
     def test_search(self):
         search_terms = {
@@ -255,7 +228,7 @@ class TestCommandTagsHelpers(TestCommandTagsBase):
         }
         for term in search_terms:
             tags = search_tags(self._site, term)
-            self.assertEqual(tags, search_terms[term])
+            assert tags == search_terms[term]
 
     def test_sort(self):
         posts = [os.path.join('posts', post) for post in os.listdir('posts')]
@@ -263,8 +236,8 @@ class TestCommandTagsHelpers(TestCommandTagsBase):
         new_tags = sort_tags(self._site, posts)
         new_parsed_tags = self._parse_new_tags(posts[0])
 
-        self.assertEqual(sorted(DEMO_TAGS), new_parsed_tags)
-        self.assertEqual(sorted(DEMO_TAGS), new_tags[0])
+        assert new_parsed_tags == sorted(DEMO_TAGS)
+        assert new_tags[0] == sorted(DEMO_TAGS)
 
     def test_sort_dry_run(self):
         posts = [os.path.join('posts', post) for post in os.listdir('posts')]
@@ -273,45 +246,34 @@ class TestCommandTagsHelpers(TestCommandTagsBase):
         new_tags = sort_tags(self._site, posts, dry_run=True)
         new_parsed_tags = self._parse_new_tags(posts[0])
 
-        self.assertEqual(old_parsed_tags, new_parsed_tags)
-        self.assertEqual(sorted(DEMO_TAGS), new_tags[0])
+        assert old_parsed_tags == new_parsed_tags
+        assert new_tags[0] == sorted(DEMO_TAGS)
 
 
 class TestCommandTags(TestCommandTagsBase):
     """ Tests that directly call the Nikola command CommandTags. """
-
-    def setUp(self):
-        """ Create a demo site, for testing. """
-
-        self._create_temp_dir_and_cd()
-        self._init_site()
-        # Don't scan for posts.  The command should do it.
-        self._copy_plugin_to_site()
-
-    def tearDown(self):
-        """ Restore world order. """
-        self._remove_temp_dir()
 
     # ### `TestCommandTags` protocol ###########################################
 
     def test_list_count_sorted(self):
         self._add_test_post(title='2', tags=['python'])
         tags = self._run_shell_command(['nikola', 'tags', '-l', '-s', 'count'])
-        self.assertTrue('python' in tags)
-        self.assertEqual('python', tags.split()[1])
+        assert 'python' in tags
+        assert tags.split()[1] == 'python'
 
-    @unittest.skipIf(sys.version_info[0] == 3, 'Py2.7 specific bug.')
+    @pytest.mark.skipif(sys.version_info[0] == 3, reason='Py2.7 specific bug.')
     def test_merge_unicode_tags(self):
         # Regression test for #63
         exit_code = self._run_command(['tags', '--merge', u'paran\xe3,parana'.encode('utf8'), 'posts/1.rst'])
-        self.assertFalse(exit_code)
+        assert exit_code == 0
 
     # ### `Private` protocol ###########################################
 
-    def _copy_plugin_to_site(self):
+    @fixture(autouse=True)
+    def _copy_plugin_to_site(self, _init_site):
         if not os.path.exists('plugins'):
             os.makedirs('plugins')
-        shutil.copytree(PLUGIN_PATH, os.path.join('plugins', 'tags'))
+        shutil.copytree(str(V7_PLUGIN_PATH / 'tags'), os.path.join('plugins', 'tags'))
 
     def _run_shell_command(self, args):
         import subprocess
@@ -321,7 +283,3 @@ class TestCommandTags(TestCommandTagsBase):
             return ''
         else:
             return output.decode('utf-8')
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/test_helloworld.py
+++ b/tests/test_helloworld.py
@@ -1,41 +1,19 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import os
-import sys
-import unittest
-
-sys.path.append(os.path.join('v7', 'helloworld'))
-
-from helloworld import Plugin as HelloWorld
-from nikola.utils import LOGGER
+from v7.helloworld.helloworld import Plugin as HelloWorld
 
 
 class MockObject:
     pass
 
 
-class TestHelloWorld(unittest.TestCase):
-    @staticmethod
-    def setUpClass():
-        LOGGER.notice('--- TESTS FOR helloworld')
-
-    @staticmethod
-    def tearDownClass():
-        sys.stdout.write('\n')
-        LOGGER.notice('--- END OF TESTS FOR helloworld')
-
+class TestHelloWorld:
     def test_gen_tasks(self):
         hw = HelloWorld()
         hw.site = MockObject()
         hw.site.config = {}
         for i in hw.gen_tasks():
-            self.assertEqual(i['basename'], 'hello_world')
-            self.assertEqual(i['uptodate'], [False])
-            try:
-                self.assertIsInstance(i['actions'][0][1][0], bool)
-            except AttributeError:
-                LOGGER.warning('Python 2.6 is missing assertIsInstance()')
-
-if __name__ == '__main__':
-    unittest.main()
+            assert i['basename'] == 'hello_world'
+            assert i['uptodate'] == [False]
+            assert isinstance(i['actions'][0][1][0], bool)


### PR DESCRIPTION
These are the easier files to convert.  They have other aspects that could be simplified such as removing 2.x specifics but I think doing it here would over complicate the PR.

The other test files all use `ReSTExtensionTestCase` so probably belong in a separate PR.