### PR TITLE
Fix: "publication_list" now records a dependency on ALL specified bibtex files

### DIFF
--- a/tests/test_publication_list.py
+++ b/tests/test_publication_list.py
@@ -5,6 +5,7 @@ import logging
 import sys
 import re
 import unittest
+from textwrap import dedent
 
 from nikola.utils import LOGGER
 
@@ -48,7 +49,10 @@ class TestPublication(ReSTExtensionTestCase):
         self.sample = ('.. publication_list:: tests/data/publication_list/test.bib '
                        'tests/data/publication_list/test1.bib'
                        '\n\t:highlight_author: Nikola Tesla')
-        self.deps = 'tests/data/publication_list/test.bib'
+        self.deps = dedent("""
+            tests/data/publication_list/test.bib
+            tests/data/publication_list/test1.bib
+            """).strip()
         self.basic_test()
         assert re.search(
             expected.replace('\n', '').strip(),

--- a/v7/publication_list/publication_list.plugin
+++ b/v7/publication_list/publication_list.plugin
@@ -9,6 +9,6 @@ Compiler = rest
 
 [Documentation]
 Author = Hong Xu
-Version = 0.7.1
+Version = 0.7.2
 Website = https://www.topbug.net
 Description = Easily manage publication list.

--- a/v7/publication_list/publication_list.py
+++ b/v7/publication_list/publication_list.py
@@ -97,7 +97,7 @@ class PublicationList(Directive):
         if highlight_authors:
             highlight_authors = highlight_authors.split(';')
         style = Style(self.site.config['BASE_URL'] + detail_page_dir if detail_page_dir else None)
-        self.state.document.settings.record_dependencies.add(self.arguments[0])
+        self.state.document.settings.record_dependencies.add(*self.arguments)
 
         all_entries = []
         labels = set()


### PR DESCRIPTION
Found while converting tests to pytest but this is clearer in its own PR.