### PR TITLE
postcast: create extra feed pages for podcast history

### DIFF
--- a/v8/postcast/conf.py.sample
+++ b/v8/postcast/conf.py.sample
@@ -59,3 +59,12 @@
 #         ('Society & Culture', ('Philosophy', )),
 #     ],
 # }
+
+# Create paged feeds with the provided number of items per page.
+# The default is to not create extra feed pages.
+# The first page will always have FEED_LENGTH items.
+# Specifying a length for the '' feed will result in all unspecified
+# feeds having that length.
+# POSTCAST_PAGE_LENGTH = {
+#     '': 100,
+# }

--- a/v8/postcast/postcast.py
+++ b/v8/postcast/postcast.py
@@ -321,6 +321,7 @@ def _itunes_image_tag(src, handler):
         handler.startElement("itunes:image", {'href': src.itunes_image})
         handler.endElement("itunes:image")
 
+
 def _atom_link(handler, rel, href):
     assert rel in ("first", "last", "previous", "next")
     handler.startElement(
@@ -332,11 +333,13 @@ def _atom_link(handler, rel, href):
     )
     handler.endElement("atom:link")
 
+
 def _chunked(posts, size):
     if size is None:
         return
     for i in range(0, len(posts), size):
-        yield posts[i : i + size]
+        yield posts[i: i + size]
+
 
 def _get_with_default_key(config, key, default_key):
     return config.get(key, config.get(default_key))


### PR DESCRIPTION
This changes nothing from the default behaviour. Paging has to be enabled explicitly by the user.

If `POSTCAST_PAGE_LENGTH` is set, if a feed has more items than `FEED_LENGTH` this change will create further .xml files ("pages") and link them from each previous page, allowing discovery of the full archive of all podcast episodes by following those links from the original/first page.
The new files are automatically named based on the slug, by appending ".page-{page numer}", e.g. `http://example.com/feeds/podcast.xml` could have further pages at `http://example.com/feeds/podcast.page-1.xml` and `http://example.com/feeds/podcast.page-2.xml`.

fixes #373 