### PR TITLE
[similarity] Ignore scheduled posts and convert to LateTask

### DIFF
--- a/v7/similarity/similarity.plugin
+++ b/v7/similarity/similarity.plugin
@@ -3,7 +3,7 @@ Name = similarity
 Module = similarity
 
 [Nikola]
-PluginCategory = Task
+PluginCategory = LateTask
 
 [Documentation]
 Author = Roberto Alsina

--- a/v7/similarity/similarity.py
+++ b/v7/similarity/similarity.py
@@ -149,10 +149,7 @@ class Similarity(LateTask):
             file_dep = [p.translated_source_path(lang) for p in timeline]
             uptodate = utils.config_changed({1: kw}, "similarity")
             for i, post in enumerate(timeline):
-                out_name = (
-                    os.path.join(kw["output_folder"], post.destination_path(lang=lang))
-                    + ".related.json"
-                )
+                out_name = os.path.join(kw["output_folder"], post.destination_path(lang=lang)) + ".related.json"
                 task = {
                     "basename": self.name,
                     "name": out_name,


### PR DESCRIPTION
First of all, apologies for the messy PR. Most changes were due to `black` formatting. I didn't see any guidelines on linter or a contributor manifest but wanted to make sure it's PEP8 compliant.

Main changes:

- make similarity respect scheduled posts in `similarity.py` in line 49 or 52 respectively using `post.publish_later`.
- Change Task to LateTask to have it run after all the posts are rendered (and the folders are created) line 35, 39 in `similarity.py` and 6 in `similarity.plugin`