### PR TITLE
Expand meta_template accepted keywords and documentation

### DIFF
--- a/v7/meta_template/README.md
+++ b/v7/meta_template/README.md
@@ -32,5 +32,7 @@ You will also need to put the file `button.tmpl` in the folder
 
 Finally, you will get the button as you expect. Easy. Doesn't it?
 
+The template accepts some classic html keywords such as 'title', 'href', 'url', 'target', 'src', 'style'. Alternatively for more general meta_templates the keywords 'template_00' through 'template_99' are accepted.
+
 Feel free to send your pull request to collaborate with more templates
 or supported options :)

--- a/v7/meta_template/meta_template.py
+++ b/v7/meta_template/meta_template.py
@@ -26,6 +26,8 @@
 
 from __future__ import unicode_literals
 
+import sys
+
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
 
@@ -53,9 +55,12 @@ class MetaTemplate(Directive):
         'src': directives.unchanged,
         'style': directives.unchanged,
     }
+
+    option_spec.update({f'template_{num:02d}': directives.unchanged for num in range(100)})
+
     has_content = True
     required_arguments = 1
-    optional_arguments = 0
+    optional_arguments = sys.maxsize
 
     def __init__(self, *args, **kwargs):
         super(MetaTemplate, self).__init__(*args, **kwargs)

--- a/v7/similarity/similarity.py
+++ b/v7/similarity/similarity.py
@@ -149,10 +149,7 @@ class Similarity(LateTask):
             file_dep = [p.translated_source_path(lang) for p in timeline]
             uptodate = utils.config_changed({1: kw}, "similarity")
             for i, post in enumerate(timeline):
-                out_name = (
-                    os.path.join(kw["output_folder"], post.destination_path(lang=lang))
-                    + ".related.json"
-                )
+                out_name = os.path.join(kw["output_folder"], post.destination_path(lang=lang)) + ".related.json"
                 task = {
                     "basename": self.name,
                     "name": out_name,


### PR DESCRIPTION
I recently built my website with Nikola and heavily relied on meta_templates to reuse code-bocks.

However, I needed to dig into the code to understand how to actually use it and ended up extending the code with general "template_00" keywords. I think this change (and the change to the Readme.md) could enhance the original plugin and make it more usable to the wider user base.

The main change is that the meta_template accepts "template_00" through "template_99" now. This was necessary because the options have to be pre-defined within the plugin, not accepting "any kind of option" unfortunately.