### PR TITLE
Change GitHub Workflow to use "setup-java" action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,17 +32,16 @@ jobs:
       - name: Install test dependencies
         run: |
           pip install pybtex
+      - name: Setup Java
+        uses: actions/setup-java@v2.2.0
+        with:
+          java-version: 11
+          distribution: 'temurin'
       - name: Install PlantUML
         env:
           PLANTUML_VERSION: 1.2020.24
         run: |
-          sudo apt update
-          # Not using "apt-get install plantuml" because it's an old version
-          sudo apt-get install default-jre-headless
-
-          # Avoid Java logging "Created user preferences directory"
-          mkdir -p ~/.java/.userPrefs
-
+          # Not using "apt-get install plantuml" because it's usually an old version
           wget -q -O "${{github.workspace}}/plantuml.jar" "https://repo1.maven.org/maven2/net/sourceforge/plantuml/plantuml/${PLANTUML_VERSION}/plantuml-${PLANTUML_VERSION}.jar"
       - name: Run tests
         env:


### PR DESCRIPTION
Changing Java setup from `apt-get` to [actions/setup-java](https://github.com/marketplace/actions/setup-java-jdk) which is the "official" way to use Java in GitHub Workflows.

This reduces CI time by about 27s.

Tests are currently failing because of #395 