### PR TITLE
Fixed ditaa example diagram URL

### DIFF
--- a/v8/ditaa/README.md
+++ b/v8/ditaa/README.md
@@ -36,7 +36,7 @@ diagrams like this:
 
 And produces this:
 
-![example](./ditaa-example.svg)
+![example](https://raw.githubusercontent.com/getnikola/plugins/master/v8/ditaa/ditaa-example.svg)
 
 (Thanks to https://github.com/changcs/ditaa-examples for this example)
 


### PR DESCRIPTION
With a relative URL, it works on GitHub, but with a full URL it should work on https://plugins.getnikola.com/v8/ditaa/ as well.