### PR TITLE
Fix encoding of files for devto import

### DIFF
--- a/v8/devto/devto_plugin.py
+++ b/v8/devto/devto_plugin.py
@@ -70,7 +70,7 @@ class CommandDevto(Command):
             LOGGER.info("Nothing new to post...")
 
         for post in to_post:
-            with open(post.source_path, 'r') as file:
+            with open(post.source_path, 'r', encoding='utf-8') as file:
                 data = file.read()
 
                 if post.source_ext() == '.md':


### PR DESCRIPTION
Explicit encoding avoids unpredictable errors in file-opens.