### PR TITLE
Add Boolean functionality to Medium and Devto plugin

### DIFF
--- a/v8/devto/README.md
+++ b/v8/devto/README.md
@@ -21,6 +21,7 @@ How to Use it
 4. Run ``nikola devto``
 
 At that point your posts with the "devto" metadata set to "yes" or "true" should be published.
+Any article that does not have "devtp" metadata, or is set to "false" will be skipped.
 This plugin is testing if your article was already published so don't worry for double posting.
 
 Enjoy!

--- a/v8/devto/devto_plugin.py
+++ b/v8/devto/devto_plugin.py
@@ -66,7 +66,7 @@ class CommandDevto(Command):
         to_post = [
             post
             for post in posts
-            if post.title() not in devto_titles and (post.meta("devto").lower() not in ["no", "false", "0"])
+            if post.title() not in devto_titles and post.meta("devto") and (post.meta("devto").lower() not in ["no", "false", "0"])
         ]
 
         if len(to_post) == 0:

--- a/v8/devto/devto_plugin.py
+++ b/v8/devto/devto_plugin.py
@@ -64,7 +64,7 @@ class CommandDevto(Command):
         posts = self.site.timeline
 
         devto_titles = {item["title"] for item in articles}
-        to_post = [post for post in posts if post.title() not in devto_titles and post.meta('devto')]
+        to_post = [post for post in posts if post.title() not in devto_titles and (post.meta('devto').lower() not in ['no', 'false', '0'])]
 
         if len(to_post) == 0:
             LOGGER.info("Nothing new to post...")

--- a/v8/devto/devto_plugin.py
+++ b/v8/devto/devto_plugin.py
@@ -34,7 +34,7 @@ import pydevto
 from nikola import utils
 from nikola.plugin_categories import Command
 
-LOGGER = utils.get_logger('Devto')
+LOGGER = utils.get_logger("Devto")
 
 
 class CommandDevto(Command):
@@ -50,13 +50,12 @@ class CommandDevto(Command):
     def _execute(self, options, args):
         """Publish to Dev.to."""
 
-        if not os.path.exists('devto.json'):
-            LOGGER.error(
-                'Please put your credentials in devto.json as described in the README.')
+        if not os.path.exists("devto.json"):
+            LOGGER.error("Please put your credentials in devto.json as described in the README.")
             return False
-        with open('devto.json') as inf:
+        with open("devto.json") as inf:
             creds = json.load(inf)
-        api = pydevto.PyDevTo(api_key=creds['TOKEN'])
+        api = pydevto.PyDevTo(api_key=creds["TOKEN"])
 
         articles = api.articles()
         self.site.scan_posts()
@@ -64,25 +63,29 @@ class CommandDevto(Command):
         posts = self.site.timeline
 
         devto_titles = {item["title"] for item in articles}
-        to_post = [post for post in posts if post.title() not in devto_titles and (post.meta('devto').lower() not in ['no', 'false', '0'])]
+        to_post = [
+            post
+            for post in posts
+            if post.title() not in devto_titles and (post.meta("devto").lower() not in ["no", "false", "0"])
+        ]
 
         if len(to_post) == 0:
             LOGGER.info("Nothing new to post...")
 
         for post in to_post:
-            with open(post.source_path, 'r') as file:
+            with open(post.source_path, "r") as file:
                 data = file.read()
 
-                if post.source_ext() == '.md':
+                if post.source_ext() == ".md":
                     content = "".join(data)
-                elif post.source_ext() == '.rst':
-                    content = pypandoc.convert_file(post.source_path, to='gfm', format='rst')
+                elif post.source_ext() == ".rst":
+                    content = pypandoc.convert_file(post.source_path, to="gfm", format="rst")
 
                 m_post = api.create_article(
                     title=post.title(),
                     body_markdown=content,
                     published=True,
                     canonical_url=post.permalink(absolute=True),
-                    tags=post.tags
+                    tags=post.tags,
                 )
-                LOGGER.info('Published {} to {}'.format(post.meta('slug'), m_post['url']))
+                LOGGER.info("Published {} to {}".format(post.meta("slug"), m_post["url"]))

--- a/v8/medium/README.md
+++ b/v8/medium/README.md
@@ -22,5 +22,6 @@ This plugin lets syndicate Nikola content to your Medium site.
 5. Run ``nikola medium``
 
 At that point your posts with the "medium" metadata set to "yes" should be published.
+Any article that does not have "medium" metadata, or is set to "false" will be skipped.
 
 **Be aware that if you use the command again after a short period of time it might post duplicate article, medium is taking a bit of time before updating the list of your posted articles that I compare from to avoid that.**

--- a/v8/medium/medium_plugin.py
+++ b/v8/medium/medium_plugin.py
@@ -66,7 +66,7 @@ class CommandMedium(Command):
         to_post = [
             post
             for post in posts
-            if post.title() not in medium_titles and post.meta("medium")
+            if post.title() not in medium_titles and (post.meta("medium").lower() not in ["no", "false", "0"])
         ]
 
         if len(to_post) == 0:

--- a/v8/medium/medium_plugin.py
+++ b/v8/medium/medium_plugin.py
@@ -66,7 +66,7 @@ class CommandMedium(Command):
         to_post = [
             post
             for post in posts
-            if post.title() not in medium_titles and (post.meta("medium").lower() not in ["no", "false", "0"])
+            if post.title() not in medium_titles and post.meta("medium") and (post.meta("medium").lower() not in ["no", "false", "0"])
         ]
 
         if len(to_post) == 0:


### PR DESCRIPTION
Addresses #404

Checks for "negating" keywords, i.e. "no", "false", or "0" in the metadata. Otherwise publishes the article to medium or devto respectively

Also chenged the fromatting of the `devto_plutin.py` using black