### PR TITLE
Podcast RSS Feed Generator Plugin

### DIFF
--- a/v8/podcast_rss/README.md
+++ b/v8/podcast_rss/README.md
@@ -1,0 +1,12 @@
+# rss_ogg
+Used for producing podcast rss.xml files when trying to publish mp3 and ogg feeds. 
+
+# usage
+Add 
+`.. ogg_enclosure: <file>` 
+and
+`.. ogg_enclosure_length: <size in bytes>` 
+to your source files to provide the ogg file and length to create a separate ogg feed. 
+
+# Other notes
+Even if you're not creating multiple feeds, many podcatchers require enclosures to have an accurate length. Please consider setting it.

--- a/v8/podcast_rss/README.md
+++ b/v8/podcast_rss/README.md
@@ -1,12 +1,22 @@
-# rss_ogg
-Used for producing podcast rss.xml files when trying to publish mp3 and ogg feeds. 
+# Podcast RSS Feed Generator
+Used for publishing RSS feeds for an arbitrary set of audio formats
 
-# usage
-Add 
-`.. ogg_enclosure: <file>` 
-and
-`.. ogg_enclosure_length: <size in bytes>` 
-to your source files to provide the ogg file and length to create a separate ogg feed. 
+# Usage
+Add the following options to your `config.py`
+```
+# List of feed types you want to create
+PODCAST_FEEDS = ['mp3', 'ogg']
+
+# Base URL for where the files are hosted
+POD_BASE_URL="https://archive.org/download/urandom-00X/urandom-00X."
+
+# Adding the 'enclosure' and 'enclosure_length' metadata to the posts, to get added to the feeds
+ADDITIONAL_METADATA = {}
+for feed in PODCAST_FEEDS:
+    ADDITIONAL_METADATA[feed + "_enclosure"] = POD_BASE_URL + feed
+    ADDITIONAL_METADATA[feed + "_enclosure_length"] = feed + "_length"
+```
+
 
 # Other notes
 Even if you're not creating multiple feeds, many podcatchers require enclosures to have an accurate length. Please consider setting it.

--- a/v8/podcast_rss/podcast_rss.plugin
+++ b/v8/podcast_rss/podcast_rss.plugin
@@ -1,0 +1,13 @@
+[Core]
+name = podcasts_rss
+module = podcast_rss
+
+[Documentation]
+author = Lyle McKarns
+version = 1.0
+website = https://getnikola.com/
+Description = Generate Podcast RSS feeds.
+
+[Nikola]
+PluginCategory = Task
+

--- a/v8/podcast_rss/podcast_rss.py
+++ b/v8/podcast_rss/podcast_rss.py
@@ -27,11 +27,11 @@
 """Generate Podcast Specific RSS Feeds"""
 
 import os
-#  import mimetypes
+import mimetypes
 try:
-  from urlparse import urljoin
+    from urlparse import urljoin
 except ImportError:
-  from urllib.parse import urljoin  # NOQA
+    from urllib.parse import urljoin  # NOQA
 from nikola import utils
 from nikola.plugin_categories import TaskMultiplier
 
@@ -74,13 +74,11 @@ class GeneratePodcastRSS(TaskMultiplier):
             'clean': True
         }
 
-
-        feeds = self.site.config['PODCAST_FEEDS']
         deps = []
         deps_uptodate = []
-        for feed in feeds:
+        for feed in self.site.config['PODCAST_FEEDS']:
             for lang in kw['translations']:
-                output_name  = os.path.join(kw['output_folder'],self.site.path('rss_' + feed, None, lang))
+                output_name = os.path.join(kw['output_folder'], self.site.path('rss_' + feed, None, lang))
 
                 if kw["show_untranslated_posts"]:
                     posts = self.site.posts[:kw['feed_length']]
@@ -90,18 +88,17 @@ class GeneratePodcastRSS(TaskMultiplier):
                     deps += post.deps(lang)
                     deps_uptodate += post.deps_uptodate(lang)
 
-                feed_url = urljoin(self.site.config['BASE_URL'], self.site.link("rss_" + feed , None, lang).lstrip('/'))
+                feed_url = urljoin(self.site.config['BASE_URL'], self.site.link("rss_" + feed, None, lang).lstrip('/'))
 
                 feed_task['actions'].append((utils.generic_rss_renderer,
-                                (lang, kw["blog_title"](lang), kw["site_url"],
-                                 kw["blog_description"](lang), posts, output_name,
-                                 kw["feed_teasers"], kw["feed_plain"], kw['feed_length'], feed_url,
-                                 self._enclosure, kw["feed_links_append_query"])))
+                                            (lang, kw["blog_title"](lang), kw["site_url"],
+                                                kw["blog_description"](lang), posts, output_name,
+                                                kw["feed_teasers"], kw["feed_plain"], kw['feed_length'], feed_url,
+                                                self._enclosure, kw["feed_links_append_query"])))
                 feed_task['targets'].append(output_name)
         feed_task['uptodate'] = deps_uptodate
         feed_task['file_dep'] = deps
         return [feed_task]
-        
 
     def _enclosure(self, post, feed, lang):
         enclosure = post.meta(feed + "_enclosure", lang)
@@ -126,11 +123,10 @@ class GeneratePodcastRSS(TaskMultiplier):
         """
         return [_f for _f in [self.site.config['TRANSLATIONS'][lang],
                               self.site.config['RSS_PATH'], 'rss_' + feed + '.xml'] if _f]
-            
+
     def set_site(self, site):
         """Set Nikola site."""
         for feed in site.config['PODCAST_FEEDS']:
             site.register_path_handler('rss_' + feed, self._rss_path)
             utils.LOGGER.warn("registering rss_" + feed)
         return super(GeneratePodcastRSS, self).set_site(site)
-

--- a/v8/podcast_rss/podcast_rss.py
+++ b/v8/podcast_rss/podcast_rss.py
@@ -44,10 +44,15 @@ class GeneratePodcastRSS(TaskMultiplier):
     def process(self, task, prefix):
 
         """Process Tasks"""
+        if not self.site.config['PODCAST_RSS']:
+            return []
         if task.get('name') is None:
             return []
 
         utils.LOGGER.warn("process called for Gen Pod Feed")
+        utils.LOGGER.warn(self.site.path_handlers)
+        # utils.LOGGER.warn(self.site.config['TRANSLATIONS'])
+        # utils.LOGGER.warn("Targets: %s", task.get('targets', []))
         kw = {
             "translations": self.site.config["TRANSLATIONS"],
             "filters": self.site.config["FILTERS"],
@@ -62,6 +67,7 @@ class GeneratePodcastRSS(TaskMultiplier):
             "feed_read_more_link": self.site.config["FEED_READ_MORE_LINK"],
             "feed_links_append_query": self.site.config["FEED_LINKS_APPEND_QUERY"],
         }
+        utils.LOGGER.warn("KW Set")
 
         feed_task = {
             'file_dep': [],
@@ -70,15 +76,22 @@ class GeneratePodcastRSS(TaskMultiplier):
             'uptodate': [],
             'basename': '{0}_podcast_rss'.format(prefix),
             'name': task.get('name').split(":", 1)[-1],
-            'task_dep': ['render_posts'],
+            'task_dep': ['render_site'],
             'clean': True
         }
+        utils.LOGGER.warn("Feed Task Set")
 
         deps = []
         deps_uptodate = []
         for feed in self.site.config['PODCAST_FEEDS']:
+            feed_name = "rss_" + feed
+            utils.LOGGER.warn("Adding action for: %s", feed)
             for lang in kw['translations']:
-                output_name = os.path.join(kw['output_folder'], self.site.path('rss_' + feed, None, lang))
+                utils.LOGGER.warn("Doing work for: %s", lang)
+                utils.LOGGER.warn("output folder: %s", kw['output_folder'])
+                utils.LOGGER.warn("output path: %s", self.site.path(feed_name, None, lang))
+                output_name = os.path.join(kw['output_folder'], self.site.path(feed_name, None, lang))
+                utils.LOGGER.warn("Setting Output to: %s", output_name)
 
                 if kw["show_untranslated_posts"]:
                     posts = self.site.posts[:kw['feed_length']]
@@ -114,19 +127,27 @@ class GeneratePodcastRSS(TaskMultiplier):
             mime = mimetypes.guess_type(url)[0]
             return url, length, mime
 
-    def _rss_path(self, lang, feed):
+    """
+    Honestly, does this need to be a method? can I make it some kind of lambda?
+    """
+    def _rss_path(self, name, lang):
         """A link to the RSS feed path.
 
         Example:
 
         link://rss => /blog/rss_ogg.xml
         """
-        return [_f for _f in [self.site.config['TRANSLATIONS'][lang],
-                              self.site.config['RSS_PATH'], 'rss_' + feed + '.xml'] if _f]
+        utils.LOGGER.warn("name: %s", name)
+        res = []
+        for feed in self.site.config['PODCAST_FEEDS']:
+            res.append([_f for _f in [self.site.config['TRANSLATIONS'][lang],
+                                      self.site.config['RSS_PATH'], 
+                                      'rss_' + feed + '.xml'] 
+                        if _f])
+        return res
 
     def set_site(self, site):
         """Set Nikola site."""
         for feed in site.config['PODCAST_FEEDS']:
             site.register_path_handler('rss_' + feed, self._rss_path)
-            utils.LOGGER.warn("registering rss_" + feed)
         return super(GeneratePodcastRSS, self).set_site(site)

--- a/v8/podcast_rss/podcast_rss.py
+++ b/v8/podcast_rss/podcast_rss.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+
+# Copyright © 2012-2016 Roberto Alsina and others.
+
+# Permission is hereby granted, free of charge, to any
+# person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the
+# Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the
+# Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice
+# shall be included in all copies or substantial portions of
+# the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+# PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+# OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""Generate Podcast Specific RSS Feeds"""
+
+import os
+#  import mimetypes
+try:
+  from urlparse import urljoin
+except ImportError:
+  from urllib.parse import urljoin  # NOQA
+from nikola import utils
+from nikola.plugin_categories import TaskMultiplier
+
+
+class GeneratePodcastRSS(TaskMultiplier):
+    """Generate Podcast Specific RSS feeds."""
+
+    name = "gen_pod_rss"
+
+    def process(self, task, prefix):
+
+        """Process Tasks"""
+        if task.get('name') is None:
+            return []
+
+        utils.LOGGER.warn("process called for Gen Pod Feed")
+        kw = {
+            "translations": self.site.config["TRANSLATIONS"],
+            "filters": self.site.config["FILTERS"],
+            "blog_title": self.site.config["BLOG_TITLE"],
+            "site_url": self.site.config["SITE_URL"],
+            "blog_description": self.site.config["BLOG_DESCRIPTION"],
+            "output_folder": self.site.config["OUTPUT_FOLDER"],
+            "feed_teasers": self.site.config["FEED_TEASERS"],
+            "feed_plain": self.site.config["FEED_PLAIN"],
+            "show_untranslated_posts": self.site.config['SHOW_UNTRANSLATED_POSTS'],
+            "feed_length": self.site.config['FEED_LENGTH'],
+            "feed_read_more_link": self.site.config["FEED_READ_MORE_LINK"],
+            "feed_links_append_query": self.site.config["FEED_LINKS_APPEND_QUERY"],
+        }
+
+        feed_task = {
+            'file_dep': [],
+            'targets': [],
+            'actions': [],
+            'uptodate': [],
+            'basename': '{0}_podcast_rss'.format(prefix),
+            'name': task.get('name').split(":", 1)[-1],
+            'task_dep': ['render_posts'],
+            'clean': True
+        }
+
+
+        feeds = self.site.config['PODCAST_FEEDS']
+        deps = []
+        deps_uptodate = []
+        for feed in feeds:
+            for lang in kw['translations']:
+                output_name  = os.path.join(kw['output_folder'],self.site.path('rss_' + feed, None, lang))
+
+                if kw["show_untranslated_posts"]:
+                    posts = self.site.posts[:kw['feed_length']]
+                else:
+                    posts = [x for x in self.site.posts if x.is_translation_available(lang)][:kw['feed_length']]
+                for post in posts:
+                    deps += post.deps(lang)
+                    deps_uptodate += post.deps_uptodate(lang)
+
+                feed_url = urljoin(self.site.config['BASE_URL'], self.site.link("rss_" + feed , None, lang).lstrip('/'))
+
+                feed_task['actions'].append((utils.generic_rss_renderer,
+                                (lang, kw["blog_title"](lang), kw["site_url"],
+                                 kw["blog_description"](lang), posts, output_name,
+                                 kw["feed_teasers"], kw["feed_plain"], kw['feed_length'], feed_url,
+                                 self._enclosure, kw["feed_links_append_query"])))
+                feed_task['targets'].append(output_name)
+        feed_task['uptodate'] = deps_uptodate
+        feed_task['file_dep'] = deps
+        return [feed_task]
+        
+
+    def _enclosure(self, post, feed, lang):
+        enclosure = post.meta(feed + "_enclosure", lang)
+        if enclosure:
+            try:
+                length = int(post.meta(feed + '_enclosure_length', lang) or 0)
+            except KeyError:
+                length = 0
+            except ValueError:
+                utils.LOGGER.warn("Invalid enclosure length for post {0}".format(post.source_path))
+                length = 0
+            url = enclosure
+            mime = mimetypes.guess_type(url)[0]
+            return url, length, mime
+
+    def _rss_path(self, lang, feed):
+        """A link to the RSS feed path.
+
+        Example:
+
+        link://rss => /blog/rss_ogg.xml
+        """
+        return [_f for _f in [self.site.config['TRANSLATIONS'][lang],
+                              self.site.config['RSS_PATH'], 'rss_' + feed + '.xml'] if _f]
+            
+    def set_site(self, site):
+        """Set Nikola site."""
+        for feed in site.config['PODCAST_FEEDS']:
+            site.register_path_handler('rss_' + feed, self._rss_path)
+            utils.LOGGER.warn("registering rss_" + feed)
+        return super(GeneratePodcastRSS, self).set_site(site)
+


### PR DESCRIPTION
First, I know already that this doesn't work. But I wanted to get what code I have up and then start some discussions on how to fix my errors. 

The goal of this is to replace my existing `rss_ogg` plugin with something that's generic for any audio format, and any number of them. As such, its a `TaskMultiplier` plugin, not a `Task` plugin.

I used my initial [`rss_ogg` plugin](https://github.com/getnikola/plugins/blob/master/v7/rss_ogg/rss_ogg.py) as a base, and then compared it to the [`gzip` plugin](https://github.com/getnikola/nikola/blob/master/nikola/plugins/task/gzip.py) to sort out how to do the task multiplication.

In its current state, when I run `nikola list` (from a demo site, with only the [plugin needed changes made to `conf.py`](https://pastebin.com/ykLtKkuA)) I get pages of [this error](https://pastebin.com/6wdJRhAk).

I know I have (at least) two distinct issues going on here with the code, and I'm sure its based on me not fully understanding something or other.

Firstly, this error seems to indicate that despite trying to register all the various paths with `site.register_path_handler()`, they don't seem to be found
```
WARNING: Nikola: Unknown path request of kind: rss_mp3
WARNING: Nikola: Unknown path request of kind: rss_mp3
WARNING: Nikola: Unknown path request of kind: rss_ogg
WARNING: Nikola: Unknown path request of kind: rss_ogg
```

Second, it seems like the `process()` method on this is being called considerably more often than I'd expected, which I believe is the culprit behind eventually getting this error
```
 ERROR: Nikola: doit.exceptions.InvalidTask: Task generation 'post_render' has duplicated definition of 'post_render_podcast_rss:sitemap'
```

What I think I'm missing/misunderstanding is 
1) how to correctly register a variable number of paths, constructed from those variables
2) where in the processing this plugin is being invoked, and how to limit that to where it needs to be (at the point where RSS feeds would normally be generated)