### PR TITLE
Discourse Comments integration

### DIFF
--- a/v8/discourse_comments/README.md
+++ b/v8/discourse_comments/README.md
@@ -1,0 +1,1 @@
+If the article includes a field `discourse_thread` it will be added on the bottom for the comments automatically the Discourse JS integration.

--- a/v8/discourse_comments/discourse_comments.plugin
+++ b/v8/discourse_comments/discourse_comments.plugin
@@ -1,0 +1,13 @@
+[Core]
+Name = discourse_comments
+Module = discourse_comments
+
+[Nikola]
+PluginCategory = CommentSystem
+
+[Documentation]
+Author = Daniele Scasciafratte
+Version = 0.1
+Website = http://plugins.getnikola.com/#discourse_comments
+Description = Add discourse comments to the article
+

--- a/v8/discourse_comments/discourse_comments.py
+++ b/v8/discourse_comments/discourse_comments.py
@@ -32,16 +32,14 @@ class DiscourseComments(CommentSystem):
 
     def set_site(self, site):
         super(DiscourseComments, self).set_site(site)
-        site.template_hooks['comment_link_script'].append(
-            "<div id='discourse-comments'></div>
-            <script type='text/javascript'>
-            var discourseUrl = '[URL from attribute]',
-              discourseEmbedUrl = '[website URL]';
-
-          (function() {
-            var d = document.createElement('script'); d.type = 'text/javascript'; d.async = true;
-              d.src = discourseUrl + 'javascripts/embed.js';
-            (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(d);
-          })();
-        </script>"
+        site.template_hooks['page_footer'].append(
+            "<div id='discourse-comments'></div>",
+            "<script type='text/javascript'>",
+            "window.DiscourseEmbed = { discourseUrl: '" + self.site.config["SITE_URL"] + "', discourseEmbedUrl: '[URL from attribute]' };",
+            "(function() {",
+                "var d = document.createElement('script'); d.type = 'text/javascript'; d.async = true;",
+                "d.src = window.DiscourseEmbed.discourseUrl + 'javascripts/embed.js';",
+                "(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(d);",
+            "})();",
+            "</script>"
         )

--- a/v8/discourse_comments/discourse_comments.py
+++ b/v8/discourse_comments/discourse_comments.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+
+# Copyright © 2012-2013 Roberto Alsina
+
+# Permission is hereby granted, free of charge, to any
+# person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the
+# Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the
+# Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice
+# shall be included in all copies or substantial portions of
+# the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+# PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+# OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+from __future__ import unicode_literals
+from nikola.plugin_categories import CommentSystem
+
+
+class DiscourseComments(CommentSystem):
+
+    def set_site(self, site):
+        super(DiscourseComments, self).set_site(site)
+        site.template_hooks['comment_link_script'].append(
+            "<div id='discourse-comments'></div>
+            <script type='text/javascript'>
+            var discourseUrl = '[URL from attribute]',
+              discourseEmbedUrl = '[website URL]';
+
+          (function() {
+            var d = document.createElement('script'); d.type = 'text/javascript'; d.async = true;
+              d.src = discourseUrl + 'javascripts/embed.js';
+            (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(d);
+          })();
+        </script>"
+        )


### PR DESCRIPTION
Ref: https://github.com/getnikola/nikola/issues/3689

So I started working but some stuff is not clear to me.

So my needs are just 2:

* I need to check if the article has a parameter `discourse_thread` and get that value
* Print in the bottom in the comment section a HTML/JS code

So right now I saw that hooks are just 6 https://getnikola.com/extending.html#toc-entry-16 and no one of them is useful for me to print in the comment section.  
It would be useful to have something to access the macro `comment_link_script` to print what I need but I didn't find anything. I see the cactus_comment instead use template files but I am not sure if this create troubles with themes.

Instead how to read a field in the article I didn't find a plugin that do that to replicate the code.

I have some doubts if it is the case to integrate it on theme side or by plugin. Or a plugin that is not a comment system but a task generator.

PS: the code is not yet tested.