### PR TITLE
Make the myst plugin compatible with myst-parser > 0.17.2

### DIFF
--- a/v8/myst/myst.py
+++ b/v8/myst/myst.py
@@ -79,7 +79,7 @@ class CompileMyst(PageCompiler):
                 source=new_data,
                 writer_name="html5",
                 settings_overrides={
-                    "myst_enable_extensions": 
+                    "myst_enable_extensions":
                         [
                             "attrs_inline",
                             "colon_fence",

--- a/v8/myst/myst.py
+++ b/v8/myst/myst.py
@@ -31,7 +31,15 @@ import os
 
 try:
     import myst_parser
-    import myst_parser.main
+    
+    # this works for myst-parser versions <= 0.17.2
+    try:
+        from myst_parser.main import to_html
+        old_myst = True
+    except ImportError:
+        from docutils.core import publish_string
+        from myst_parser.docutils_ import Parser
+        old_myst = False
 except ImportError:
     myst_parser = None
     nikola_extension = None
@@ -63,7 +71,34 @@ class CompileMyst(PageCompiler):
         if not is_two_file:
             _, data = self.split_metadata(data, post, lang)
         new_data, shortcodes = sc.extract_shortcodes(data)
-        output = myst_parser.main.to_html(new_data)
+        
+        if old_myst:
+            output = to_html(new_data)
+        else:
+            output = publish_string(
+                source=new_data,
+                writer_name="html5",
+                settings_overrides={
+                    "myst_enable_extensions": [
+                            "attrs_inline",
+                            "colon_fence",
+                            "deflist",
+                            "fieldlist",
+                            "html_admonition",
+                            "html_image",
+                            "linkify",
+                            "smartquotes",
+                            "strikethrough",
+                            "substitution",
+                            "tasklist",
+                        ],
+                    "embed_stylesheet": True,
+                    'output_encoding': 'unicode',
+                    'myst_suppress_warnings': ["myst.header"],
+                    'myst_heading_anchors' : 4
+                },
+                parser=Parser(),
+            )
         output, shortcode_deps = self.site.apply_shortcodes_uuid(
             output, shortcodes, filename=source_path, extra_context={"post": post}
         )

--- a/v8/myst/myst.py
+++ b/v8/myst/myst.py
@@ -31,7 +31,7 @@ import os
 
 try:
     import myst_parser
-    
+
     # this works for myst-parser versions <= 0.17.2
     try:
         from myst_parser.main import to_html
@@ -71,7 +71,7 @@ class CompileMyst(PageCompiler):
         if not is_two_file:
             _, data = self.split_metadata(data, post, lang)
         new_data, shortcodes = sc.extract_shortcodes(data)
-        
+
         if old_myst:
             output = to_html(new_data)
         else:
@@ -79,7 +79,8 @@ class CompileMyst(PageCompiler):
                 source=new_data,
                 writer_name="html5",
                 settings_overrides={
-                    "myst_enable_extensions": [
+                    "myst_enable_extensions": 
+                        [
                             "attrs_inline",
                             "colon_fence",
                             "deflist",
@@ -95,7 +96,7 @@ class CompileMyst(PageCompiler):
                     "embed_stylesheet": True,
                     'output_encoding': 'unicode',
                     'myst_suppress_warnings': ["myst.header"],
-                    'myst_heading_anchors' : 4
+                    'myst_heading_anchors': 4
                 },
                 parser=Parser(),
             )


### PR DESCRIPTION
As discussed in #428 , the myst plugin is not compatible with myst-parser > 0.17.2 (which is already more than one year old). The patch contained in this PR keeps the plugin backward compatible with older myst-parser versions, but also supports the new versions by using [docutils.core's publish_string](https://docutils.sourceforge.io/docs/api/publisher.html#publish-string), as suggested in [the docs](https://myst-parser.readthedocs.io/en/latest/docutils.html).

In principle with the `publish_string` method it is possible to list the myst extensions one wants to enable. Here I am enabling them all but support for mathematical equations (which is handled directly by nikola). I have also decided to suppress warnings related to out-of-order document headings, and to have myst add anchors to headers (i.e. lines starting with one or more #) in order to support internal links.