### PR TITLE
Add PluginCategory metadata for WordPress compiler plugin's plugins

### DIFF
--- a/v7/wordpress_compiler/wordpress/plugins/wordpress_shortcode_code.plugin
+++ b/v7/wordpress_compiler/wordpress/plugins/wordpress_shortcode_code.plugin
@@ -4,6 +4,7 @@ Module = wordpress_shortcode_code
 
 [Nikola]
 Compiler = wordpress
+PluginCategory = CompilerExtension
 
 [Documentation]
 Author = Felix Fontein

--- a/v7/wordpress_compiler/wordpress/plugins/wordpress_shortcode_gallery.plugin
+++ b/v7/wordpress_compiler/wordpress/plugins/wordpress_shortcode_gallery.plugin
@@ -4,6 +4,7 @@ Module = wordpress_shortcode_gallery
 
 [Nikola]
 Compiler = wordpress
+PluginCategory = CompilerExtension
 
 [Documentation]
 Author = Felix Fontein


### PR DESCRIPTION
This is needed for https://github.com/getnikola/nikola/pull/3728.