### PR TITLE
Remove "Wisecrack Edition"

### DIFF
--- a/v7/continuous_import/templates/mako/youtube.tmpl
+++ b/v7/continuous_import/templates/mako/youtube.tmpl
@@ -3,8 +3,8 @@ ${item['summary_detail']['value']}
 % endif
 
 <div style="position: relative; width: 100%; height: 0; padding-bottom: 56.25%;">
-<iframe src="https://www.youtube.com/embed/${item['links'][0]['href'].split('=')[-1]}" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height:100%;" 
-srcdoc="<style>*{padding:0;margin:0;overflow:hidden}html,body{height:100%}img,span{position:absolute;width:100%;top:0;bottom:0;margin:auto}span{height:1.5em;text-align:center;font:48px/1.5 sans-serif;color:white;text-shadow:0 0 0.5em black}</style><a href=https://www.youtube.com/embed/Y8Wp3dafaMQ?autoplay=1><img src=https://img.youtube.com/vi/Y8Wp3dafaMQ/hqdefault.jpg alt='Video The Dark Knight Rises: What Went Wrong? – Wisecrack Edition'><span>▶</span></a>"
+<iframe src="https://www.youtube.com/embed/${item['links'][0]['href'].split('=')[-1]}" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height:100%;"
+srcdoc="<style>*{padding:0;margin:0;overflow:hidden}html,body{height:100%}img,span{position:absolute;width:100%;top:0;bottom:0;margin:auto}span{height:1.5em;text-align:center;font:48px/1.5 sans-serif;color:white;text-shadow:0 0 0.5em black}</style><a href=https://www.youtube.com/embed/${item['links'][0]['href'].split('=')[-1]}?autoplay=1><img src=https://img.youtube.com/vi/${item['links'][0]['href'].split('=')[-1]}/hqdefault.jpg ><span>▶</span></a>"
 
 ></iframe>
 </div>


### PR DESCRIPTION
As is, the Wisecrack edition shows up on the blog website. Modified to have to have the proper video displayed.