### PR TITLE
LaTeX plugin: fix type check

### DIFF
--- a/v7/latex/latex/parser.py
+++ b/v7/latex/latex/parser.py
@@ -338,10 +338,12 @@ class Parser:
         if isinstance(block, tree.Block):
             while True:
                 if len(block.elements) == 1 and isinstance(block.elements[0], tree.Block):
-                    if isinstance(block, tree.Block):
+                    # Note that the two if conditions below cannot use isinstance()
+                    # since we do not want to match any class derived from Block!
+                    if type(block) == tree.Block:
                         block.elements[0].labels.extend(block.labels)
                         block = block.elements[0]
-                    elif isinstance(block.elements[0], tree.Block):
+                    elif type(block.elements[0]) == tree.Block:
                         block.labels.extend(block.elements[0].labels)
                         block.elements = block.elements[0].elements
                     else:

--- a/v7/latex/latex/parser.py
+++ b/v7/latex/latex/parser.py
@@ -340,10 +340,10 @@ class Parser:
                 if len(block.elements) == 1 and isinstance(block.elements[0], tree.Block):
                     # Note that the two if conditions below cannot use isinstance()
                     # since we do not want to match any class derived from Block!
-                    if type(block) == tree.Block:
+                    if type(block) is tree.Block:
                         block.elements[0].labels.extend(block.labels)
                         block = block.elements[0]
-                    elif type(block.elements[0]) == tree.Block:
+                    elif type(block.elements[0]) is tree.Block:
                         block.labels.extend(block.elements[0].labels)
                         block.elements = block.elements[0].elements
                     else:

--- a/v7/latex/latex/tree.py
+++ b/v7/latex/latex/tree.py
@@ -341,7 +341,7 @@ class TikzPicture(Formula):
 
     def __str__(self):
         """Generate textual representation."""
-        return "TikzPicture(" + self.args + "; " + repr(self.formula) + ")"
+        return "TikzPicture(" + str(self.args) + "; " + repr(self.formula) + ")"
 
     def visit(self, visitor, *args, **kw):
         """Process with TreeVisitor object. Passes ``args`` and ``kw`` to the corresponding method of ``visitor``."""


### PR DESCRIPTION
f7b2e69e133fcf46332cb3cbb18b4dd2daeb79ed introduced a subtle bug: two `if` conditions should only match `Block` instances, but not instances of classes derived from `Block`. Changing `type(...) == Block` to `isinstance(..., Block)` makes it match derived classes as well.