### PR TITLE
Correct the name of wordpress_compiler plugin in metadata

### DIFF
--- a/v7/wordpress_compiler/wordpress_compiler.plugin
+++ b/v7/wordpress_compiler/wordpress_compiler.plugin
@@ -1,5 +1,5 @@
 [Core]
-Name = wordpress
+Name = wordpress_compiler
 Module = wordpress
 
 [Nikola]


### PR DESCRIPTION
This allows the plugin to be updated by `nikola plugin --upgrade`