### PR TITLE
Revert "Correct the name of wordpress_compiler plugin in metadata"

### DIFF
--- a/v7/wordpress_compiler/wordpress_compiler.plugin
+++ b/v7/wordpress_compiler/wordpress_compiler.plugin
@@ -1,5 +1,5 @@
 [Core]
-Name = wordpress_compiler
+Name = wordpress
 Module = wordpress
 
 [Nikola]


### PR DESCRIPTION
Reverts getnikola/plugins#454

I could've tested this better…

Compiling is now broken, as everyone expects this compiler to be called `wordpress`, but we call it `wordpress_compiler` with this patch :see_no_evil: 