### PR TITLE
enable content search in flexsearch plugin

### DIFF
--- a/v8/flexsearch_plugin/flexsearch_plugin.py
+++ b/v8/flexsearch_plugin/flexsearch_plugin.py
@@ -61,7 +61,7 @@ class FlexSearchPlugin(LateTask):
                 if item.is_post and index_posts:
                     index[item.meta('slug')] = {
                         'title': item.title(),
-                        # 'content': item.text(strip_html=True),
+                        'content': item.text(strip_html=True),
                         'tags': item.meta('tags'),
                         'url': item.permalink(),
                         'type': 'post'
@@ -70,7 +70,7 @@ class FlexSearchPlugin(LateTask):
                 elif not item.is_post and index_pages:
                     index[item.meta('slug')] = {
                         'title': item.title(),
-                        # 'content': item.text(strip_html=True),
+                        'content': item.text(strip_html=True),
                         'tags': item.meta('tags'),
                         'url': item.permalink(),
                         'type': 'page'


### PR DESCRIPTION
this was enabled in the past and then accidentally disabled

Fixes: 1f1975fa15bf15dd1840e236e55388971066f288